### PR TITLE
I²C for u8g2 with ssd1306

### DIFF
--- a/hardware/displays/U8G2/test_SSD1306_i2c.c
+++ b/hardware/displays/U8G2/test_SSD1306_i2c.c
@@ -1,0 +1,59 @@
+#include <driver/gpio.h>
+#include <driver/spi_master.h>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <stdio.h>
+#include <string.h>
+#include <u8g2.h>
+
+#include "sdkconfig.h"
+#include "u8g2_esp32_hal.h"
+
+// SDA - GPIO21
+#define PIN_SDA 21
+
+// SCL - GPIO22
+#define PIN_SCL 22
+
+static const char *TAG = "ssd1306";
+
+void task_test_SSD1306i2c(void *ignore) {
+	u8g2_esp32_hal_t u8g2_esp32_hal = U8G2_ESP32_HAL_DEFAULT;
+	u8g2_esp32_hal.sda   = PIN_SDA;
+	u8g2_esp32_hal.scl  = PIN_SCL;
+	u8g2_esp32_hal_init(u8g2_esp32_hal);
+
+
+	u8g2_t u8g2; // a structure which will contain all the data for one display
+	u8g2_Setup_ssd1306_128x32_univision_f(
+		&u8g2,
+		U8G2_R0,
+		//u8x8_byte_sw_i2c,
+		u8g2_esp32_msg_i2c_cb,
+		u8g2_esp32_msg_i2c_and_delay_cb);  // init u8g2 structure
+	u8x8_SetI2CAddress(&u8g2.u8x8,0x78);
+
+	ESP_LOGI(TAG, "u8g2_InitDisplay");
+	u8g2_InitDisplay(&u8g2); // send init sequence to the display, display is in sleep mode after this,
+
+	ESP_LOGI(TAG, "u8g2_SetPowerSave");
+	u8g2_SetPowerSave(&u8g2, 0); // wake up display
+	ESP_LOGI(TAG, "u8g2_ClearBuffer");
+	u8g2_ClearBuffer(&u8g2);
+	ESP_LOGI(TAG, "u8g2_DrawBox");
+	u8g2_DrawBox(&u8g2, 0, 26, 80,6);
+	u8g2_DrawFrame(&u8g2, 0,26,100,6);
+
+	ESP_LOGI(TAG, "u8g2_SetFont");
+    u8g2_SetFont(&u8g2, u8g2_font_ncenB14_tr);
+	ESP_LOGI(TAG, "u8g2_DrawStr");
+    u8g2_DrawStr(&u8g2, 2,17,"Hi nkolban!");
+	ESP_LOGI(TAG, "u8g2_SendBuffer");
+	u8g2_SendBuffer(&u8g2);
+
+	ESP_LOGI(TAG, "All done!");
+
+	vTaskDelete(NULL);
+}
+

--- a/hardware/displays/U8G2/u8g2_esp32_hal.c
+++ b/hardware/displays/U8G2/u8g2_esp32_hal.c
@@ -1,19 +1,21 @@
-#include <driver/gpio.h>
-#include <driver/spi_master.h>
-#include <esp_log.h>
-#include <freertos/FreeRTOS.h>
-#include <freertos/task.h>
 #include <stdio.h>
 #include <string.h>
-#include <u8g2.h>
 
 #include "sdkconfig.h"
+#include "esp_log.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
 #include "u8g2_esp32_hal.h"
 
-//static char tag[] = "u8g2_esp32_hal";
+static const char *TAG = "u8g2_hal";
 
 static spi_device_handle_t handle; // SPI handle.
 static u8g2_esp32_hal_t u8g2_esp32_hal; // HAL state data.
+
+#undef ESP_ERROR_CHECK
+#define ESP_ERROR_CHECK(x)   do { esp_err_t rc = (x); if (rc != ESP_OK) { ESP_LOGE("err", "esp_err_t = %d", rc); assert(0 && #x);} } while(0);
 
 /*
  * Initialze the ESP32 HAL.
@@ -21,107 +23,6 @@ static u8g2_esp32_hal_t u8g2_esp32_hal; // HAL state data.
 void u8g2_esp32_hal_init(u8g2_esp32_hal_t u8g2_esp32_hal_param) {
 	u8g2_esp32_hal = u8g2_esp32_hal_param;
 } // u8g2_esp32_hal_init
-
-
-/*
-static char *bytesToString(int length, char *data) {
-	static char ret[1024];
-	strcpy(ret, "");
-	int i;
-	char temp[10];
-	for (i=0; i<length; i++) {
-		sprintf(temp, "%.2x ", data[i]);
-		strcat(ret, temp);
-	}
-	return ret;
-}
-
-
-static char *msgToString(uint8_t msg, uint8_t arg_int, void *arg_ptr) {
-	static char buf[1024];
-	switch(msg)
-	{
-	case U8X8_MSG_GPIO_AND_DELAY_INIT:  // called once during init phase of u8g2/u8x8
-		return "U8X8_MSG_GPIO_AND_DELAY_INIT";                            // can be used to setup pins
-
-	case U8X8_MSG_DELAY_NANO:           // delay arg_int * 1 nano second
-		sprintf(buf, "U8X8_MSG_DELAY_NANO: %d ns", arg_int);
-		return buf;
-
-	    case U8X8_MSG_DELAY_100NANO:        // delay arg_int * 100 nano seconds
-	      return "U8X8_MSG_DELAY_100NANO";
-	    case U8X8_MSG_DELAY_10MICRO:        // delay arg_int * 10 micro seconds
-	    	return "U8X8_MSG_DELAY_10MICRO";
-
-	case U8X8_MSG_DELAY_MILLI:          // delay arg_int * 1 milli second
-		sprintf(buf, "U8X8_MSG_DELAY_MILLI: %d ms", arg_int);
-		return buf;
-
-	    case U8X8_MSG_DELAY_I2C:                // arg_int is the I2C speed in 100KHz, e.g. 4 = 400 KHz
-	    	return "U8X8_MSG_DELAY_I2C";
-	      break;                            // arg_int=1: delay by 5us, arg_int = 4: delay by 1.25us
-	    case U8X8_MSG_GPIO_D0:              // D0 or SPI clock pin: Output level in arg_int
-	    //case U8X8_MSG_GPIO_SPI_CLOCK:
-	      return "U8X8_MSG_GPIO_D0";
-	    case U8X8_MSG_GPIO_D1:              // D1 or SPI data pin: Output level in arg_int
-	    //case U8X8_MSG_GPIO_SPI_DATA:
-	      return "U8X8_MSG_GPIO_D1";
-	    case U8X8_MSG_GPIO_D2:              // D2 pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_D2";
-	    case U8X8_MSG_GPIO_D3:              // D3 pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_D3";
-	    case U8X8_MSG_GPIO_D4:              // D4 pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_D4";
-	    case U8X8_MSG_GPIO_D5:              // D5 pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_D5";
-	    case U8X8_MSG_GPIO_D6:              // D6 pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_D6";
-	    case U8X8_MSG_GPIO_D7:              // D7 pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_D7";
-	    case U8X8_MSG_GPIO_E:               // E/WR pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_E";
-	    case U8X8_MSG_GPIO_CS:              // CS (chip select) pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_CS";
-	    case U8X8_MSG_GPIO_DC:              // DC (data/cmd, A0, register select) pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_DC";
-	 case U8X8_MSG_GPIO_RESET:           // Reset pin: Output level in arg_int
-		 sprintf(buf, "U8X8_MSG_GPIO_RESET -> %d", arg_int);
-		 return buf;
-
-	    case U8X8_MSG_GPIO_CS1:             // CS1 (chip select) pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_CS1";
-	    case U8X8_MSG_GPIO_CS2:             // CS2 (chip select) pin: Output level in arg_int
-	      return "U8X8_MSG_GPIO_CS2";
-	    case U8X8_MSG_GPIO_I2C_CLOCK:       // arg_int=0: Output low at I2C clock pin
-	      return "U8X8_MSG_GPIO_I2C_CLOCK";                            // arg_int=1: Input dir with pullup high for I2C clock pin
-	    case U8X8_MSG_GPIO_I2C_DATA:            // arg_int=0: Output low at I2C data pin
-	      return "U8X8_MSG_GPIO_I2C_DATA";                            // arg_int=1: Input dir with pullup high for I2C data pin
-	    case U8X8_MSG_GPIO_MENU_SELECT:
-	      return "U8X8_MSG_GPIO_MENU_SELECT";
-	    case U8X8_MSG_GPIO_MENU_NEXT:
-	      return "U8X8_MSG_GPIO_MENU_NEXT";
-	    case U8X8_MSG_GPIO_MENU_PREV:
-	      return "U8X8_MSG_GPIO_MENU_PREV";
-	    case U8X8_MSG_GPIO_MENU_HOME:
-	    	return "U8X8_MSG_GPIO_MENU_HOME";
-	    case U8X8_MSG_BYTE_SEND:
-	    	sprintf(buf, "U8X8_MSG_BYTE_SEND: length=%d %s", arg_int, bytesToString(arg_int, arg_ptr));
-	    	return buf;
-	    case U8X8_MSG_BYTE_INIT:
-	    	return "U8X8_MSG_BYTE_INIT";
-	    case U8X8_MSG_BYTE_END_TRANSFER:
-	    	return "U8X8_MSG_BYTE_END_TRANSFER";
-	    case U8X8_MSG_BYTE_START_TRANSFER:
-	    	return "U8X8_MSG_BYTE_START_TRANSFER";
-	    case U8X8_MSG_BYTE_SET_DC:
-	    	sprintf(buf, "U8X8_MSG_BYTE_SET_DC -> %d", arg_int);
-	    	return buf;
-	    default:
-	      return "Unknown";
-	  }
-}
-*/
-
 
 /*
  * HAL callback function as prescribed by the U8G2 library.  This callback is invoked
@@ -152,24 +53,7 @@ uint8_t u8g2_esp32_msg_comms_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void
 		  //ESP_LOGI(tag, "... Initializing bus.");
 		  ESP_ERROR_CHECK(spi_bus_initialize(HSPI_HOST, &bus_config, 1));
 
-
-			spi_device_interface_config_t dev_config;
-			dev_config.address_bits     = 0;
-			dev_config.command_bits     = 0;
-			dev_config.dummy_bits       = 0;
-			dev_config.mode             = 0;
-			dev_config.duty_cycle_pos   = 0;
-			dev_config.cs_ena_posttrans = 0;
-			dev_config.cs_ena_pretrans  = 0;
-			dev_config.clock_speed_hz   = 10000;
-			dev_config.spics_io_num     = u8g2_esp32_hal.cs;
-			dev_config.flags            = 0;
-			dev_config.queue_size       = 200;
-			dev_config.pre_cb           = NULL;
-			dev_config.post_cb          = NULL;
-			//ESP_LOGI(tag, "... Adding device bus.");
-			ESP_ERROR_CHECK(spi_bus_add_device(HSPI_HOST, &dev_config, &handle));
-			break;
+		   break;
 		}
 
 		case U8X8_MSG_BYTE_SEND: {
@@ -190,6 +74,92 @@ uint8_t u8g2_esp32_msg_comms_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void
 	return 0;
 } // u8g2_esp32_msg_comms_cb
 
+/*
+ * HAL callback function as prescribed by the U8G2 library.  This callback is invoked
+ * to handle callbacks for communications.
+ */
+uint8_t u8g2_esp32_msg_i2c_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr) {
+
+	ESP_LOGD(TAG, "msg_i2c_cb: Received a msg: %d %d", msg, arg_int);
+	//ESP_LOGD(tag, "msg_i2c_cb: Received a msg: %d: %s", msg, msgToString(msg, arg_int, arg_ptr));
+
+	switch(msg) {
+		case U8X8_MSG_BYTE_SET_DC:
+			if (u8g2_esp32_hal.dc != U8G2_ESP32_HAL_UNDEFINED) {
+				gpio_set_level(u8g2_esp32_hal.dc, arg_int);
+			}
+			break;
+
+		case U8X8_MSG_BYTE_INIT: {
+			if (u8g2_esp32_hal.sda == U8G2_ESP32_HAL_UNDEFINED ||
+					u8g2_esp32_hal.scl == U8G2_ESP32_HAL_UNDEFINED) {
+				break;
+			}
+
+		    i2c_config_t conf;
+		    conf.mode = I2C_MODE_MASTER;
+			ESP_LOGI(TAG, "sda_io_num %d", u8g2_esp32_hal.sda);
+		    conf.sda_io_num = u8g2_esp32_hal.sda;
+		    conf.sda_pullup_en = GPIO_PULLUP_ENABLE;
+			ESP_LOGI(TAG, "scl_io_num %d", u8g2_esp32_hal.scl);
+		    conf.scl_io_num = u8g2_esp32_hal.scl;
+		    conf.scl_pullup_en = GPIO_PULLUP_ENABLE;
+			ESP_LOGI(TAG, "clk_speed %d", I2C_MASTER_FREQ_HZ);
+		    conf.master.clk_speed = I2C_MASTER_FREQ_HZ;
+			ESP_LOGI(TAG, "i2c_param_config %d", conf.mode);
+		    ESP_ERROR_CHECK(i2c_param_config(I2C_MASTER_NUM, &conf));
+			ESP_LOGI(TAG, "i2c_driver_install %d", I2C_MASTER_NUM);
+		    ESP_ERROR_CHECK(i2c_driver_install(I2C_MASTER_NUM, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0));
+/*
+			i2c_cmd_handle_t cmd = i2c_cmd_link_create(); // dummy write
+			ESP_ERROR_CHECK(i2c_master_start(cmd));
+			ESP_ERROR_CHECK(i2c_master_write_byte(cmd, 0x00 | I2C_MASTER_WRITE, ACK_CHECK_DIS));
+			ESP_ERROR_CHECK(i2c_master_stop(cmd));
+			ESP_LOGI(TAG, "i2c_master_cmd_begin %d", I2C_MASTER_NUM);
+			ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS));
+			i2c_cmd_link_delete(cmd);
+*/
+
+			break;
+		}
+
+		case U8X8_MSG_BYTE_SEND: {
+			uint8_t *data;
+			uint8_t cmddata;
+			i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+			ESP_ERROR_CHECK(i2c_master_start(cmd));
+//			ESP_LOGI(TAG, "I2CAddress %02X", u8x8_GetI2CAddress(u8x8)>>1);
+			ESP_ERROR_CHECK(i2c_master_write_byte(cmd, u8x8_GetI2CAddress(u8x8) | I2C_MASTER_WRITE, ACK_CHECK_EN));
+		    data = (uint8_t *)arg_ptr;
+			if (arg_int==1) {
+				cmddata=0;
+				ESP_ERROR_CHECK(i2c_master_write(cmd, &cmddata, 1, ACK_CHECK_EN));
+//				   printf("0x%02X ",zerodata);
+			} else {
+				cmddata=0x40;
+				ESP_ERROR_CHECK(i2c_master_write(cmd, &cmddata, 1, ACK_CHECK_EN));
+				//bzero(arg_ptr,arg_int);
+				//*data=0x40;
+			}
+			//ESP_ERROR_CHECK(i2c_master_write(cmd, arg_ptr, arg_int, ACK_CHECK_EN));
+
+		    while( arg_int > 0 ) {
+			   ESP_ERROR_CHECK(i2c_master_write_byte(cmd, *data, ACK_CHECK_EN));
+//			   printf("0x%02X ",*data);
+			   data++;
+			   arg_int--;
+		    }
+//			printf("\n");
+
+			ESP_ERROR_CHECK(i2c_master_stop(cmd));
+//			ESP_LOGI(TAG, "i2c_master_cmd_begin %d", I2C_MASTER_NUM);
+			ESP_ERROR_CHECK(i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, 1000 / portTICK_RATE_MS));
+			i2c_cmd_link_delete(cmd);
+			break;
+		}
+	}
+	return 0;
+} // u8g2_esp32_msg_i2c_cb
 
 /*
  * HAL callback function as prescribed by the U8G2 library.  This callback is invoked
@@ -224,6 +194,82 @@ uint8_t u8g2_esp32_msg_gpio_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_
 		case U8X8_MSG_GPIO_RESET:
 			if (u8g2_esp32_hal.reset != U8G2_ESP32_HAL_UNDEFINED) {
 				gpio_set_level(u8g2_esp32_hal.reset, arg_int);
+			}
+			break;
+
+	// Delay for the number of milliseconds passed in through arg_int.
+		case U8X8_MSG_DELAY_MILLI:
+			vTaskDelay(arg_int/portTICK_PERIOD_MS);
+			break;
+	}
+	return 0;
+} // u8g2_esp32_msg_gpio_and_delay_cb
+
+/*
+ * HAL callback function as prescribed by the U8G2 library.  This callback is invoked
+ * to handle callbacks for I²C and delay functions.
+ */
+uint8_t u8g2_esp32_msg_i2c_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr) {
+
+	ESP_LOGD(TAG, "msg_i2c_and_delay_cb: Received a msg: %d", msg);
+
+	switch(msg) {
+	// Initialize the GPIO and DELAY HAL functions.  If the pins for DC and RESET have been
+	// specified then we define those pins as GPIO outputs.
+		case U8X8_MSG_GPIO_AND_DELAY_INIT: {
+			uint64_t bitmask = 0;
+			if (u8g2_esp32_hal.dc != U8G2_ESP32_HAL_UNDEFINED) {
+				bitmask = bitmask | (1<<u8g2_esp32_hal.dc);
+			}
+			if (u8g2_esp32_hal.reset != U8G2_ESP32_HAL_UNDEFINED) {
+				bitmask = bitmask | (1<<u8g2_esp32_hal.reset);
+			}
+			if (u8g2_esp32_hal.cs != U8G2_ESP32_HAL_UNDEFINED) {
+				bitmask = bitmask | (1<<u8g2_esp32_hal.cs);
+			}
+			if (u8g2_esp32_hal.sda != U8G2_ESP32_HAL_UNDEFINED) {
+				//bitmask = bitmask | (1<<u8g2_esp32_hal.sda);
+			}
+			if (u8g2_esp32_hal.scl != U8G2_ESP32_HAL_UNDEFINED) {
+				//bitmask = bitmask | (1<<u8g2_esp32_hal.scl);
+			}
+            if (bitmask==0) {
+            	break;
+            }
+			gpio_config_t gpioConfig;
+			gpioConfig.pin_bit_mask = bitmask;
+			gpioConfig.mode         = GPIO_MODE_OUTPUT;
+			gpioConfig.pull_up_en   = GPIO_PULLUP_DISABLE;
+			gpioConfig.pull_down_en = GPIO_PULLDOWN_ENABLE;
+			gpioConfig.intr_type    = GPIO_INTR_DISABLE;
+			gpio_config(&gpioConfig);
+			break;
+		}
+
+	// Set the GPIO reset pin to the value passed in through arg_int.
+		case U8X8_MSG_GPIO_RESET:
+			if (u8g2_esp32_hal.reset != U8G2_ESP32_HAL_UNDEFINED) {
+				gpio_set_level(u8g2_esp32_hal.reset, arg_int);
+			}
+			break;
+	// Set the GPIO client select pin to the value passed in through arg_int.
+		case U8X8_MSG_GPIO_CS:
+			if (u8g2_esp32_hal.cs != U8G2_ESP32_HAL_UNDEFINED) {
+				gpio_set_level(u8g2_esp32_hal.cs, arg_int);
+			}
+			break;
+	// Set the Software I²C pin to the value passed in through arg_int.
+		case U8X8_MSG_GPIO_I2C_CLOCK:
+			if (u8g2_esp32_hal.scl != U8G2_ESP32_HAL_UNDEFINED) {
+				gpio_set_level(u8g2_esp32_hal.scl, arg_int);
+//				printf("%c",(arg_int==1?'C':'c'));
+			}
+			break;
+	// Set the Software I²C pin to the value passed in through arg_int.
+		case U8X8_MSG_GPIO_I2C_DATA:
+			if (u8g2_esp32_hal.sda != U8G2_ESP32_HAL_UNDEFINED) {
+				gpio_set_level(u8g2_esp32_hal.sda, arg_int);
+//				printf("%c",(arg_int==1?'D':'d'));
 			}
 			break;
 

--- a/hardware/displays/U8G2/u8g2_esp32_hal.h
+++ b/hardware/displays/U8G2/u8g2_esp32_hal.h
@@ -7,22 +7,36 @@
 
 #ifndef U8G2_ESP32_HAL_H_
 #define U8G2_ESP32_HAL_H_
-#include <driver/gpio.h>
-#include <u8g2.h>
+#include "u8g2.h"
+
+#include "driver/gpio.h"
+#include "driver/spi_master.h"
+#include "driver/i2c.h"
 
 #define U8G2_ESP32_HAL_UNDEFINED (-1)
+
+#define I2C_MASTER_NUM I2C_NUM_1   /*!< I2C port number for master dev */
+#define I2C_MASTER_TX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
+#define I2C_MASTER_RX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
+#define I2C_MASTER_FREQ_HZ    50000     /*!< I2C master clock frequency */
+#define ACK_CHECK_EN   0x1     /*!< I2C master will check ack from slave*/
+#define ACK_CHECK_DIS  0x0     /*!< I2C master will not check ack from slave */
 
 typedef struct {
 	gpio_num_t clk;
 	gpio_num_t mosi;
+	gpio_num_t sda; // data for I²C
+	gpio_num_t scl; // clock for I²C
 	gpio_num_t cs;
 	gpio_num_t reset;
 	gpio_num_t dc;
 } u8g2_esp32_hal_t ;
 
-#define U8G2_ESP32_HAL_DEFAULT {U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED }
+#define U8G2_ESP32_HAL_DEFAULT {U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED }
 
 void u8g2_esp32_hal_init(u8g2_esp32_hal_t u8g2_esp32_hal_param);
 uint8_t u8g2_esp32_msg_comms_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
 uint8_t u8g2_esp32_msg_gpio_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+uint8_t u8g2_esp32_msg_i2c_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+uint8_t u8g2_esp32_msg_i2c_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
 #endif /* U8G2_ESP32_HAL_H_ */


### PR DESCRIPTION
Adding i²C to the u8g2_esp32_hal and include a sample task
- still don't know why the i²C have to be set (0x3C)
- still don't know why the I²C commandcode have to be added (0x00 or 0x40)