### PR TITLE
Arduino Makefile: BLEServerCallback.cpp not existent

### DIFF
--- a/cpp_utils/Makefile.arduino
+++ b/cpp_utils/Makefile.arduino
@@ -35,7 +35,6 @@ BLE_FILES= \
 	BLERemoteService.h \
 	BLEScan.cpp \
 	BLEScan.h \
-	BLEServerCallbacks.cpp \
 	BLEServer.cpp \
 	BLEServer.h \
 	BLEService.cpp \


### PR DESCRIPTION
because this file doesn't exist any more in the current version and building for the Arduino fails then.