### PR TITLE
Bug fix and cleanup. I2C version of HAL was not functional with current u8g2 version

### DIFF
--- a/hardware/displays/U8G2/test_SSD1306.c
+++ b/hardware/displays/U8G2/test_SSD1306.c
@@ -40,16 +40,16 @@ void task_test_SSD1306(void *ignore) {
 	u8g2_Setup_ssd1306_128x64_noname_f(
 		&u8g2,
 		U8G2_R0,
-		u8g2_esp32_msg_comms_cb,
-		u8g2_esp32_msg_gpio_and_delay_cb);  // init u8g2 structure
+		u8g2_esp32_spi_byte_cb,
+		u8g2_esp32_gpio_and_delay_cb);  // init u8g2 structure
 
 	u8g2_InitDisplay(&u8g2); // send init sequence to the display, display is in sleep mode after this,
 
 	u8g2_SetPowerSave(&u8g2, 0); // wake up display
 	u8g2_ClearBuffer(&u8g2);
 	u8g2_DrawBox(&u8g2, 10,20, 20, 30);
-  u8g2_SetFont(&u8g2, u8g2_font_ncenB14_tr);
-  u8g2_DrawStr(&u8g2, 0,15,"Hello World!");
+	u8g2_SetFont(&u8g2, u8g2_font_ncenB14_tr);
+	u8g2_DrawStr(&u8g2, 0,15,"Hello World!");
 	u8g2_SendBuffer(&u8g2);
 
 	ESP_LOGD(tag, "All done!");

--- a/hardware/displays/U8G2/test_SSD1306_i2c.c
+++ b/hardware/displays/U8G2/test_SSD1306_i2c.c
@@ -26,12 +26,12 @@ void task_test_SSD1306i2c(void *ignore) {
 
 
 	u8g2_t u8g2; // a structure which will contain all the data for one display
-	u8g2_Setup_ssd1306_128x32_univision_f(
+	u8g2_Setup_ssd1306_i2c_128x32_univision_f(
 		&u8g2,
 		U8G2_R0,
 		//u8x8_byte_sw_i2c,
-		u8g2_esp32_msg_i2c_cb,
-		u8g2_esp32_msg_i2c_and_delay_cb);  // init u8g2 structure
+		u8g2_esp32_i2c_byte_cb,
+		u8g2_esp32_gpio_and_delay_cb);  // init u8g2 structure
 	u8x8_SetI2CAddress(&u8g2.u8x8,0x78);
 
 	ESP_LOGI(TAG, "u8g2_InitDisplay");

--- a/hardware/displays/U8G2/u8g2_esp32_hal.h
+++ b/hardware/displays/U8G2/u8g2_esp32_hal.h
@@ -15,12 +15,12 @@
 
 #define U8G2_ESP32_HAL_UNDEFINED (-1)
 
-#define I2C_MASTER_NUM I2C_NUM_1   /*!< I2C port number for master dev */
-#define I2C_MASTER_TX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
-#define I2C_MASTER_RX_BUF_DISABLE   0   /*!< I2C master do not need buffer */
-#define I2C_MASTER_FREQ_HZ    50000     /*!< I2C master clock frequency */
-#define ACK_CHECK_EN   0x1     /*!< I2C master will check ack from slave*/
-#define ACK_CHECK_DIS  0x0     /*!< I2C master will not check ack from slave */
+#define I2C_MASTER_NUM I2C_NUM_1           //  I2C port number for master dev
+#define I2C_MASTER_TX_BUF_DISABLE   0      //  I2C master do not need buffer
+#define I2C_MASTER_RX_BUF_DISABLE   0      //  I2C master do not need buffer
+#define I2C_MASTER_FREQ_HZ          50000  //  I2C master clock frequency
+#define ACK_CHECK_EN   0x1                 //  I2C master will check ack from slave
+#define ACK_CHECK_DIS  0x0                 //  I2C master will not check ack from slave
 
 typedef struct {
 	gpio_num_t clk;
@@ -35,8 +35,7 @@ typedef struct {
 #define U8G2_ESP32_HAL_DEFAULT {U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED, U8G2_ESP32_HAL_UNDEFINED }
 
 void u8g2_esp32_hal_init(u8g2_esp32_hal_t u8g2_esp32_hal_param);
-uint8_t u8g2_esp32_msg_comms_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
-uint8_t u8g2_esp32_msg_gpio_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
-uint8_t u8g2_esp32_msg_i2c_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
-uint8_t u8g2_esp32_msg_i2c_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+uint8_t u8g2_esp32_spi_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+uint8_t u8g2_esp32_i2c_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
+uint8_t u8g2_esp32_gpio_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr);
 #endif /* U8G2_ESP32_HAL_H_ */


### PR DESCRIPTION
Hi,
I found your snippets in the process of getting to work my cheap esp32 board. In particular TTGO Esp32 OLED+18650. It uses ssd1306 128x64 over I2C.
I followed what Luca Dentella wrote (http://www.lucadentella.it/en/2017/10/30/esp32-25-display-oled-con-u8g2/) , but was not able to get it running. It worked with other libs for ssd1306, but not u8g2 and this hal. 
It turned out that the ESP32 hal  was incorrectly sending each data byte as a separate I2C transaction (with address, command byte etc)
I corrected that and made some cleanup in the file: mainly removed dead code, fixed some debugging info, and merged gpio_delay functions. I think gpio_delay functions are only mcu specific not bus specific.
I tested that with SSD1306 using I2C. I don't have any other hardware to test it against, so it's hard to tell how it behaves with spi oled. Still I thought that it may be something to share. 

I know that renaming functions "breaks the api" of this hal, but it may still be a small price to pay for a clean naming.
Btw: Great work with all the snippets!