### PR TITLE
Improve stability on BLE notify() - Issue#209 - https://github.com/nk…

### DIFF
--- a/cpp_utils/tests/BLETests/Arduino/BLE_notify/BLE_notify.ino
+++ b/cpp_utils/tests/BLETests/Arduino/BLE_notify/BLE_notify.ino
@@ -23,8 +23,10 @@
 #include <BLEUtils.h>
 #include <BLE2902.h>
 
+BLEServer *pServer = NULL;
 BLECharacteristic *pCharacteristic;
 bool deviceConnected = false;
+bool oldDeviceConnected = false;
 uint8_t value = 0;
 
 // See the following for generating UUIDs:
@@ -53,7 +55,7 @@ void setup() {
   BLEDevice::init("MyESP32");
 
   // Create the BLE Server
-  BLEServer *pServer = BLEDevice::createServer();
+  pServer = BLEDevice::createServer();
   pServer->setCallbacks(new MyServerCallbacks());
 
   // Create the BLE Service
@@ -81,13 +83,23 @@ void setup() {
 }
 
 void loop() {
-
-  if (deviceConnected) {
-    Serial.printf("*** NOTIFY: %d ***\n", value);
-    pCharacteristic->setValue(&value, 1);
-    pCharacteristic->notify();
-    //pCharacteristic->indicate();
-    value++;
-  }
-  delay(2000);
+    // notify changed value
+    if (pCharacteristic->isReadyForData()) {
+        pCharacteristic->setValue(&value, 1);
+        pCharacteristic->notify();
+        value++;
+        delay(10); // bluetooth stack will go into congestion, if too many packets are sent
+    }
+    // disconnecting
+    if (!deviceConnected && oldDeviceConnected) {
+        delay(500); // give the bluetooth stack the chance to get things ready
+        pServer->startAdvertising(); // restart advertising
+        Serial.println("start advertising");
+        oldDeviceConnected = deviceConnected;
+    }
+    // connecting
+    if (deviceConnected && !oldDeviceConnected) {
+        // do stuff here on connecting
+        oldDeviceConnected = deviceConnected;
+    }
 }


### PR DESCRIPTION
While doing adaptions for the ble_uart sample, i forgot to change ble_notify-sample.

This changeset makes this catch up.

I did not find any more arduino samples which rely on the BLEServer-code which started ble-advertising automatically after disconnect. My changes cause, that this has to be done in the main program now. So there could be the need to Change other samples too or find a way, how BLEServer can do this automatically.

The problem is, that BLEServer has no thread to do anything triggered by a time delay.