### PR TITLE
after an start it should be resend the address

### DIFF
--- a/cpp_utils/I2C.cpp
+++ b/cpp_utils/I2C.cpp
@@ -248,6 +248,7 @@ void I2C::start() {
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "i2c_master_start: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 	}
+	m_directionKnown = false;
 } // start
 
 


### PR DESCRIPTION
as example for the bm280:

i2cBus.setAddress(0x77);
	i2cBus.beginTransaction();
	i2cBus.write(BME280_CHIP_ID_ADDR, true);
	i2cBus.start();
	i2cBus.read(&chip_id, false);
	i2cBus.endTransaction();