### PR TITLE
Issue #209 - reverted to single threaded operation

### DIFF
--- a/cpp_utils/BLECharacteristic.cpp
+++ b/cpp_utils/BLECharacteristic.cpp
@@ -45,7 +45,6 @@ BLECharacteristic::BLECharacteristic(BLEUUID uuid, uint32_t properties) {
 	m_handle     = NULL_HANDLE;
 	m_properties = (esp_gatt_char_prop_t)0;
 	m_pCallbacks = nullptr;
-	m_bConnected = false;
 
 	setBroadcastProperty((properties & PROPERTY_BROADCAST) !=0);
 	setReadProperty((properties & PROPERTY_READ) !=0);
@@ -414,12 +413,10 @@ void BLECharacteristic::handleGATTServerEvent(
 
 		case ESP_GATTS_CONNECT_EVT:
 			m_semaphoreConfEvt.give();
-			m_bConnected = true;
 			break;
 
 		case ESP_GATTS_DISCONNECT_EVT:
 			m_semaphoreConfEvt.give();
-			m_bConnected = false;
 			break;
 
 		default: {
@@ -690,17 +687,6 @@ void BLECharacteristic::setWriteProperty(bool value) {
 		m_properties = (esp_gatt_char_prop_t)(m_properties & ~ESP_GATT_CHAR_PROP_BIT_WRITE);
 	}
 } // setWriteProperty
-
-  /**
-  * @brief, non-blocking check, whether API is ready to receive data
-  * @return true - if connected and sempahore is not yet taken
-  */
-bool BLECharacteristic::isReadyForData()
-{
-	bool bTaken = m_semaphoreConfEvt.isTaken();
-	ESP_LOGV(LOG_TAG, " = %d", !bTaken && m_bConnected);
-	return !bTaken && m_bConnected;
-}
 
 /**
  * @brief Return a string representation of the characteristic.

--- a/cpp_utils/BLECharacteristic.h
+++ b/cpp_utils/BLECharacteristic.h
@@ -78,7 +78,6 @@ public:
 	void setWriteNoResponseProperty(bool value);
 	std::string toString();
 	uint16_t getHandle();
-	bool isReadyForData();
 
 	static const uint32_t PROPERTY_READ      = 1<<0;
 	static const uint32_t PROPERTY_WRITE     = 1<<1;
@@ -100,7 +99,6 @@ private:
 	BLECharacteristicCallbacks* m_pCallbacks;
 	BLEService*                 m_pService;
 	BLEValue                    m_value;
-	volatile bool               m_bConnected;
 
 	void handleGATTServerEvent(
 			esp_gatts_cb_event_t      event,

--- a/cpp_utils/FreeRTOS.cpp
+++ b/cpp_utils/FreeRTOS.cpp
@@ -200,25 +200,6 @@ void FreeRTOS::Semaphore::take(uint32_t timeoutMs, std::string owner) {
 	ESP_LOGV(LOG_TAG, "Semaphore taken:  %s", toString().c_str());
 } // Semaphore::take
 
-/**
- * @brief non blocking check, if a semaphore is already taken by another thread
- * @return true - if sempahore has already been taken by another thread.
- */
-bool FreeRTOS::Semaphore::isTaken() {
-	bool bTaken = true;
-	ESP_LOGV(LOG_TAG, "Semaphore taken check" );
-
-	if (m_usePthreads) {
-		assert(false);
-	  ESP_LOGV(LOG_TAG, "Semaphore::IsTaken illegal mode usePthreads");
-	} else {
-		if( ( bTaken = xSemaphoreTake(m_semaphore, 0) ) )
-			xSemaphoreGive( m_semaphore );
-		ESP_LOGV(LOG_TAG, "Semaphore taken:  %d", !bTaken);
-	}
-	return !bTaken;
-} // Semaphore::isTaken
-
 std::string FreeRTOS::Semaphore::toString() {
 	std::stringstream stringStream;
 	stringStream << "name: "<< m_name << " (0x" << std::hex << std::setfill('0') << (uint32_t)m_semaphore << "), owner: " << m_owner;

--- a/cpp_utils/FreeRTOS.h
+++ b/cpp_utils/FreeRTOS.h
@@ -40,7 +40,6 @@ public:
 		void        take(uint32_t timeoutMs, std::string owner="<Unknown>");
 		std::string toString();
 		uint32_t    wait(std::string owner="<Unknown>");
-		bool        isTaken();
 
 	private:
 		SemaphoreHandle_t m_semaphore;

--- a/cpp_utils/tests/BLETests/Arduino/BLE_notify/BLE_notify.ino
+++ b/cpp_utils/tests/BLETests/Arduino/BLE_notify/BLE_notify.ino
@@ -24,7 +24,6 @@
 #include <BLE2902.h>
 
 BLEServer *pServer = NULL;
-BLECharacteristic *pCharacteristic;
 bool deviceConnected = false;
 bool oldDeviceConnected = false;
 uint8_t value = 0;
@@ -62,7 +61,7 @@ void setup() {
   BLEService *pService = pServer->createService(SERVICE_UUID);
 
   // Create a BLE Characteristic
-  pCharacteristic = pService->createCharacteristic(
+  BLECharacteristic * pCharacteristic = pService->createCharacteristic(
                       CHARACTERISTIC_UUID,
                       BLECharacteristic::PROPERTY_READ   |
                       BLECharacteristic::PROPERTY_WRITE  |
@@ -84,7 +83,7 @@ void setup() {
 
 void loop() {
     // notify changed value
-    if (pCharacteristic->isReadyForData()) {
+    if (deviceConnected) {
         pCharacteristic->setValue(&value, 1);
         pCharacteristic->notify();
         value++;

--- a/cpp_utils/tests/BLETests/Arduino/BLE_uart/BLE_uart.ino
+++ b/cpp_utils/tests/BLETests/Arduino/BLE_uart/BLE_uart.ino
@@ -25,8 +25,7 @@
 #include <BLE2902.h>
 
 BLEServer *pServer = NULL;
-BLECharacteristic *pTxCharacteristic;
-BLECharacteristic *pRxCharacteristic;
+BLECharacteristic * pTxCharacteristic;
 bool deviceConnected = false;
 bool oldDeviceConnected = false;
 uint8_t txValue = 0;
@@ -81,16 +80,16 @@ void setup() {
 
   // Create a BLE Characteristic
   pTxCharacteristic = pService->createCharacteristic(
-                      CHARACTERISTIC_UUID_TX,
-                      BLECharacteristic::PROPERTY_NOTIFY
-                    );
+										CHARACTERISTIC_UUID_TX,
+										BLECharacteristic::PROPERTY_NOTIFY
+									);
                       
   pTxCharacteristic->addDescriptor(new BLE2902());
 
-  pRxCharacteristic = pService->createCharacteristic(
-                                         CHARACTERISTIC_UUID_RX,
-                                         BLECharacteristic::PROPERTY_WRITE
-                                       );
+  BLECharacteristic * pRxCharacteristic = pService->createCharacteristic(
+											 CHARACTERISTIC_UUID_RX,
+											BLECharacteristic::PROPERTY_WRITE
+										);
 
   pRxCharacteristic->setCallbacks(new MyCallbacks());
 
@@ -104,8 +103,7 @@ void setup() {
 
 void loop() {
 
-    if (pTxCharacteristic->isReadyForData())
-    {
+    if (deviceConnected) {
         pTxCharacteristic->setValue(&txValue, 1);
         pTxCharacteristic->notify();
         txValue++;
@@ -113,16 +111,14 @@ void loop() {
 	}
 
     // disconnecting
-    if (!deviceConnected && oldDeviceConnected)
-    {
+    if (!deviceConnected && oldDeviceConnected) {
         delay(500); // give the bluetooth stack the chance to get things ready
         pServer->startAdvertising(); // restart advertising
         Serial.println("start advertising");
         oldDeviceConnected = deviceConnected;
     }
     // connecting
-    if (deviceConnected && !oldDeviceConnected)
-    {
+    if (deviceConnected && !oldDeviceConnected) {
 		// do stuff here on connecting
         oldDeviceConnected = deviceConnected;
     }


### PR DESCRIPTION
See comments in issue #209:
- Useless semaphore polling removed. 
- Examples for BLE_uart and BLE_notify adapted correspondingly.

Changes tested with the samples mentioned above.