### PR TITLE
Extend WiFiEventHandler. Add info arguments.

### DIFF
--- a/cpp_utils/NeoPixelWiFiEventHandler.cpp
+++ b/cpp_utils/NeoPixelWiFiEventHandler.cpp
@@ -23,14 +23,14 @@ esp_err_t NeoPixelWiFiEventHandler::apStart() {
 	return ESP_OK;
 }
 
-esp_err_t NeoPixelWiFiEventHandler::staConnected() {
+esp_err_t NeoPixelWiFiEventHandler::staConnected(system_event_sta_connected_t info) {
 	printf("XXX staConnected\n");
 	ws2812->setPixel(0, 57, 89, 66);
 	ws2812->show();
 	return ESP_OK;
 }
 
-esp_err_t NeoPixelWiFiEventHandler::staDisconnected() {
+esp_err_t NeoPixelWiFiEventHandler::staDisconnected(system_event_sta_disconnected_t info) {
 	printf("XXX staDisconnected\n");
 	ws2812->setPixel(0, 64, 0, 0);
 	ws2812->show();
@@ -44,7 +44,7 @@ esp_err_t NeoPixelWiFiEventHandler::staStart() {
 	return ESP_OK;
 }
 
-esp_err_t NeoPixelWiFiEventHandler::staGotIp(system_event_sta_got_ip_t event_sta_got_ip) {
+esp_err_t NeoPixelWiFiEventHandler::staGotIp(system_event_sta_got_ip_t info) {
 	printf("XXX staGotIp\n");
 	ws2812->setPixel(0, 0, 64, 0);
 	ws2812->show();

--- a/cpp_utils/NeoPixelWiFiEventHandler.h
+++ b/cpp_utils/NeoPixelWiFiEventHandler.h
@@ -23,9 +23,9 @@ public:
 	virtual ~NeoPixelWiFiEventHandler();
 
 	esp_err_t apStart() override;
-	esp_err_t staConnected() override;
-	esp_err_t staGotIp(system_event_sta_got_ip_t event_sta_got_ip) override;
-	esp_err_t staDisconnected() override;
+	esp_err_t staConnected(system_event_sta_connected_t info) override;
+	esp_err_t staGotIp(system_event_sta_got_ip_t info) override;
+	esp_err_t staDisconnected(system_event_sta_disconnected_t info) override;
 	esp_err_t wifiReady() override;
 	esp_err_t staStart() override;
 private:

--- a/cpp_utils/WiFiEventHandler.cpp
+++ b/cpp_utils/WiFiEventHandler.cpp
@@ -44,22 +44,32 @@ esp_err_t WiFiEventHandler::eventHandler(void* ctx, system_event_t* event) {
 		}
 
 		case SYSTEM_EVENT_AP_STACONNECTED: {
-			rc = pWiFiEventHandler->apStaConnected();
+			rc = pWiFiEventHandler->apStaConnected(event->event_info.sta_connected);
 			break;
 		}
 
 		case SYSTEM_EVENT_AP_STADISCONNECTED: {
-			rc = pWiFiEventHandler->apStaDisconnected();
+			rc = pWiFiEventHandler->apStaDisconnected(event->event_info.sta_disconnected);
+			break;
+		}
+
+		case SYSTEM_EVENT_SCAN_DONE: {
+			rc = pWiFiEventHandler->staScanDone(event->event_info.scan_done);
+			break;
+		}
+
+		case SYSTEM_EVENT_STA_AUTHMODE_CHANGE: {
+			rc = pWiFiEventHandler->staAuthChange(event->event_info.auth_change);
 			break;
 		}
 
 		case SYSTEM_EVENT_STA_CONNECTED: {
-			rc = pWiFiEventHandler->staConnected();
+			rc = pWiFiEventHandler->staConnected(event->event_info.connected);
 			break;
 		}
 
 		case SYSTEM_EVENT_STA_DISCONNECTED: {
-			rc = pWiFiEventHandler->staDisconnected();
+			rc = pWiFiEventHandler->staDisconnected(event->event_info.disconnected);
 			break;
 		}
 
@@ -123,7 +133,7 @@ system_event_cb_t WiFiEventHandler::getEventHandler() {
  * @param [in] event_sta_got_ip The Station Got IP event.
  * @return An indication of whether or not we processed the event successfully.
  */
-esp_err_t WiFiEventHandler::staGotIp(system_event_sta_got_ip_t event_sta_got_ip) {
+esp_err_t WiFiEventHandler::staGotIp(system_event_sta_got_ip_t info) {
     ESP_LOGD(LOG_TAG, "default staGotIp");
     return ESP_OK;
 } // staGotIp
@@ -169,28 +179,76 @@ esp_err_t WiFiEventHandler::staStop() {
 } // staStop
 
 
-esp_err_t WiFiEventHandler::staConnected() {
+/**
+ * @brief Handle the Station Connected event.
+ * Handle having connected to remote AP.
+ * @param [in] event_connected system_event_sta_connected_t.
+ * @return An indication of whether or not we processed the event successfully.
+ */
+esp_err_t WiFiEventHandler::staConnected(system_event_sta_connected_t info) {
     ESP_LOGD(LOG_TAG, "default staConnected");
     return ESP_OK;
 } // staConnected
 
 
-esp_err_t WiFiEventHandler::staDisconnected() {
+/**
+ * @brief Handle the Station Disconnected event.
+ * Handle having disconnected from remote AP.
+ * @param [in] event_disconnected system_event_sta_disconnected_t.
+ * @return An indication of whether or not we processed the event successfully.
+ */
+esp_err_t WiFiEventHandler::staDisconnected(system_event_sta_disconnected_t info) {
     ESP_LOGD(LOG_TAG, "default staDisconnected");
     return ESP_OK;
 } // staDisconnected
 
 
-esp_err_t WiFiEventHandler::apStaConnected() {
+/**
+ * @brief Handle a Station Connected to AP event.
+ * Handle having a station connected to ESP32 soft-AP.
+ * @param [in] event_sta_connected system_event_ap_staconnected_t.
+ * @return An indication of whether or not we processed the event successfully.
+ */
+esp_err_t WiFiEventHandler::apStaConnected(system_event_ap_staconnected_t info) {
     ESP_LOGD(LOG_TAG, "default apStaConnected");
     return ESP_OK;
 } // apStaConnected
 
 
-esp_err_t WiFiEventHandler::apStaDisconnected() {
+/**
+ * @brief Handle a Station Disconnected from AP event.
+ * Handle having a station disconnected from ESP32 soft-AP.
+ * @param [in] event_sta_disconnected system_event_ap_stadisconnected_t.
+ * @return An indication of whether or not we processed the event successfully.
+ */
+esp_err_t WiFiEventHandler::apStaDisconnected(system_event_ap_stadisconnected_t info) {
     ESP_LOGD(LOG_TAG, "default apStaDisconnected");
     return ESP_OK;
 } // apStaDisconnected
+
+
+/**
+ * @brief Handle a Scan for APs done event.
+ * Handle having an ESP32 station scan (APs) done.
+ * @param [in] event_scan_done system_event_sta_scan_done_t.
+ * @return An indication of whether or not we processed the event successfully.
+ */
+esp_err_t WiFiEventHandler::staScanDone(system_event_sta_scan_done_t info) {
+    ESP_LOGD(LOG_TAG, "default staScanDone");
+    return ESP_OK;
+} // staScanDone
+
+
+/**
+ * @brief Handle the auth mode of APs change event.
+ * Handle having the auth mode of AP ESP32 station connected to changed.
+ * @param [in] event_auth_change system_event_sta_authmode_change_t.
+ * @return An indication of whether or not we processed the event successfully.
+ */
+esp_err_t WiFiEventHandler::staAuthChange(system_event_sta_authmode_change_t info) {
+    ESP_LOGD(LOG_TAG, "default staAuthChange");
+    return ESP_OK;
+} // staAuthChange
 
 
 WiFiEventHandler::~WiFiEventHandler() {

--- a/cpp_utils/WiFiEventHandler.h
+++ b/cpp_utils/WiFiEventHandler.h
@@ -22,13 +22,15 @@
  * wifi.startAP("MYSSID", "password");
  *
  * The overridable functions are:
- * * esp_err_t apStaConnected()
- * * esp_err_t apStaDisconnected()
+ * * esp_err_t apStaConnected(system_event_ap_staconnected_t info)
+ * * esp_err_t apStaDisconnected(system_event_ap_stadisconnected_t info)
  * * esp_err_t apStart()
  * * esp_err_t apStop()
- * * esp_err_t staConnected()
- * * esp_err_t staDisconnected()
- * * esp_err_t staGotIp(system_event_sta_got_ip_t event_sta_got_ip)
+ * * esp_err_t staConnected(system_event_sta_connected_t info)
+ * * esp_err_t staDisconnected(system_event_sta_disconnected_t info)
+ * * esp_err_t staGotIp(system_event_sta_got_ip_t info)
+ * * esp_err_t staScanDone(system_event_sta_scan_done_t info)
+ * * esp_err_t staAuthChange(system_event_sta_authmode_change_t info)
  * * esp_err_t staStart()
  * * esp_err_t staStop()
  * * esp_err_t wifiReady()
@@ -56,11 +58,19 @@
  *   return ESP_OK;
  * }
  *
- * esp_err_t MyHandler::staConnected() {
+ * esp_err_t MyHandler::staConnected(system_event_sta_connected_t info) {
  *   return ESP_OK;
  * }
  *
- * esp_err_t MyHandler::staDisconnected() {
+ * esp_err_t MyHandler::staDisconnected(system_event_sta_disconnected_t info) {
+ *   return ESP_OK;
+ * }
+ *
+ * esp_err_t MyHandler::apStaConnected(system_event_ap_staconnected_t info) {
+ *   return ESP_OK;
+ * }
+ *
+ * esp_err_t MyHandler::apStaDisconnected(system_event_ap_stadisconnected_t info) {
  *   return ESP_OK;
  * }
  *
@@ -68,7 +78,15 @@
  *   return ESP_OK;
  * }
  *
- * esp_err_t MyHandler::staGotIp(system_event_sta_got_ip_t event_sta_got_ip) {
+ * esp_err_t MyHandler::staGotIp(system_event_sta_got_ip_t info) {
+ *   return ESP_OK;
+ * }
+ *
+ * esp_err_t MyHandler::staScanDone(system_event_sta_scan_done_t info) {
+ *   return ESP_OK;
+ * }
+ *
+ * esp_err_t MyHandler::staAuthChange(system_event_sta_authmode_change_t info) {
  *   return ESP_OK;
  * }
  *
@@ -81,14 +99,16 @@ class WiFiEventHandler {
 public:
 	WiFiEventHandler();
 	virtual ~WiFiEventHandler();
-	virtual esp_err_t apStaConnected();
-	virtual esp_err_t apStaDisconnected();
+	virtual esp_err_t apStaConnected(system_event_ap_staconnected_t info);
+	virtual esp_err_t apStaDisconnected(system_event_ap_stadisconnected_t info);
 	virtual esp_err_t apStart();
 	virtual esp_err_t apStop();
 	system_event_cb_t getEventHandler();
-	virtual esp_err_t staConnected();
-	virtual esp_err_t staDisconnected();
-	virtual esp_err_t staGotIp(system_event_sta_got_ip_t event_sta_got_ip);
+	virtual esp_err_t staConnected(system_event_sta_connected_t info);
+	virtual esp_err_t staDisconnected(system_event_sta_disconnected_t info);
+	virtual esp_err_t staGotIp(system_event_sta_got_ip_t info);
+	virtual esp_err_t staScanDone(system_event_sta_scan_done_t info);
+	virtual esp_err_t staAuthChange(system_event_sta_authmode_change_t info);
 	virtual esp_err_t staStart();
 	virtual esp_err_t staStop();
 	virtual esp_err_t wifiReady();

--- a/cpp_utils/cpp_utils
+++ b/cpp_utils/cpp_utils
@@ -1,1 +1,0 @@
-/home/kolban/esp32/esptest/apps/workspace/esp32-snippets/cpp_utils


### PR DESCRIPTION
Please review this request and decline it if brakes your code because i changed the parameter for got_ip.
Briefly: Added two more methods:
**staScanDone(system_event_sta_scan_done_t info)**
**staAuthChange(system_event_sta_authmode_change_t info)**

The event for 6 more methods is passed to the overridden method the same way as **staGotIp** so i can use it like:
> virtual esp_err_t apStaConnected(system_event_ap_staconnected_t info)
> {
>      printf("New client connected. ");
>      printf("MAC Address : %02x:%02x:%02x:%02x:%02x:%02x\n",
>      (unsigned char) info.mac[0],
>      (unsigned char) info.mac[1],
>      (unsigned char) info.mac[2],
>      (unsigned char) info.mac[3],
>      (unsigned char) info.mac[4],
>      (unsigned char) info.mac[5]);
> }

Output: **New client connected. MAC Address : ec:1f:72:9a:7e:43**
This class was used in **NeoPixelWiFiEventHandler** too so i fixed it. The problem is that i changed staGotIp(system_event_sta_got_ip_t **info**)
