### PR TITLE
Use uart given as parameter to read line from GPS

### DIFF
--- a/hardware/gps/Fragments/log_to_console.c
+++ b/hardware/gps/Fragments/log_to_console.c
@@ -8,7 +8,7 @@ char *readLine(uart_port_t uart) {
 	int size;
 	char *ptr = line;
 	while(1) {
-		size = uart_read_bytes(UART_NUM_1, (unsigned char *)ptr, 1, portMAX_DELAY);
+		size = uart_read_bytes(uart, (unsigned char *)ptr, 1, portMAX_DELAY);
 		if (size == 1) {
 			if (*ptr == '\n') {
 				*ptr = 0;

--- a/hardware/gps/gps/main/gps.c
+++ b/hardware/gps/gps/main/gps.c
@@ -11,7 +11,7 @@ char *readLine(uart_port_t uart) {
 	int size;
 	char *ptr = line;
 	while(1) {
-		size = uart_read_bytes(UART_NUM_1, (unsigned char *)ptr, 1, portMAX_DELAY);
+		size = uart_read_bytes(uart, (unsigned char *)ptr, 1, portMAX_DELAY);
 		if (size == 1) {
 			if (*ptr == '\n') {
 				ptr++;


### PR DESCRIPTION
Previously the uart paramter has been ignored and UART1 has
always been used to read a line from GPS.