### PR TITLE
Added WebSocket::send for binary data (issue #380)

### DIFF
--- a/cpp_utils/WebSocket.h
+++ b/cpp_utils/WebSocket.h
@@ -91,6 +91,7 @@ public:
 	WebSocketHandler* getHandler();
 	Socket            getSocket();
 	void              send(std::string data, uint8_t sendType = SEND_TYPE_BINARY);
+	void              send(uint8_t* data, uint16_t length, uint8_t sendType = SEND_TYPE_BINARY);
 	void              setHandler(WebSocketHandler *handler);
 }; // WebSocket
 


### PR DESCRIPTION
One could argue that the sendType paramater is superflous for this call.