### PR TITLE
Advertising Interval

### DIFF
--- a/cpp_utils/BLEAdvertising.cpp
+++ b/cpp_utils/BLEAdvertising.cpp
@@ -91,6 +91,16 @@ void BLEAdvertising::setAppearance(uint16_t appearance) {
 	m_advData.appearance = appearance;
 } // setAppearance
 
+void BLEAdvertising::setMinInterval(uint16_t mininterval) {
+	m_advData.min_interval = mininterval;
+	m_advParams.adv_int_min = mininterval;
+} // setMinInterval
+
+void BLEAdvertising::setMaxInterval(uint16_t maxinterval) {
+	m_advData.max_interval = maxinterval;
+	m_advParams.adv_int_max = maxinterval;
+} // setMaxInterval
+
 
 /**
  * @brief Set the filtering for the scan filter.

--- a/cpp_utils/BLEAdvertising.h
+++ b/cpp_utils/BLEAdvertising.h
@@ -52,6 +52,8 @@ public:
 	void start();
 	void stop();
 	void setAppearance(uint16_t appearance);
+	void setMaxInterval(uint16_t maxinterval);
+	void setMinInterval(uint16_t mininterval);
 	void setAdvertisementData(BLEAdvertisementData& advertisementData);
 	void setScanFilter(bool scanRequertWhitelistOnly, bool connectWhitelistOnly);
 	void setScanResponseData(BLEAdvertisementData& advertisementData);


### PR DESCRIPTION
It should be possible to create an Apple iBeacon using the setFlags() and setManufacturerData() methods for the BLEAdvertisementData class.  But the Apple specification calls for a 100ms minimum and maximum transmission interval.

This minor change would add two setter methods to BLEAdvertising to setMaxInterval(uint16_t maxinterval) and setMinInterval(uint16_t maxinterval).  

In addition to the iBeacon capability, the ability to increase advertising interval will extend life of battery operated devices somewhat dramatically.  The BLE spec allows intervals up to about 10 seconds in 0.625 ms increments.