### PR TITLE
Update u8g2_esp32_hal.c

### DIFF
--- a/hardware/displays/U8G2/u8g2_esp32_hal.c
+++ b/hardware/displays/U8G2/u8g2_esp32_hal.c
@@ -176,13 +176,13 @@ uint8_t u8g2_esp32_gpio_and_delay_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int,
 		case U8X8_MSG_GPIO_AND_DELAY_INIT: {
 			uint64_t bitmask = 0;
 			if (u8g2_esp32_hal.dc != U8G2_ESP32_HAL_UNDEFINED) {
-				bitmask = bitmask | (1<<u8g2_esp32_hal.dc);
+				bitmask = bitmask | (1ull<<u8g2_esp32_hal.dc);
 			}
 			if (u8g2_esp32_hal.reset != U8G2_ESP32_HAL_UNDEFINED) {
-				bitmask = bitmask | (1<<u8g2_esp32_hal.reset);
+				bitmask = bitmask | (1ull<<u8g2_esp32_hal.reset);
 			}
 			if (u8g2_esp32_hal.cs != U8G2_ESP32_HAL_UNDEFINED) {
-				bitmask = bitmask | (1<<u8g2_esp32_hal.cs);
+				bitmask = bitmask | (1ull<<u8g2_esp32_hal.cs);
 			}
 
             if (bitmask==0) {


### PR DESCRIPTION
To ensure use of GPIO32 & GPIO33 are supported (34-39 are input only), must define literal constant as 'unsigned long long', or the compiler produces code that fails to perform the required shift, resulting in corruption of the GPIO matrix.
I did some tests to verify behavior, and verified the compiler does generate WARNINGS when the shift count is 32 or greater, but it does not generate an ERROR (as I believe it SHOULD).

Also interesting, when the count is 31, an error is NOT generated, but the value generated IS corrupt.
For instance:
uint64_t test = (1 << 31);
results in test = 0xFFFFFFFF80000000. So the result of shifting the literal constant '1' left by 31 bits is treated as a SIGNED 32-bit integer then sign-extended to 64-bits before assigning to the variable test, even though test is defined as an UNSIGNED 64-bit value. This is a compiler bug. 
According to the C standard, shifting left by a count greater than the width of the receiving type results in undefined behavior, but that doesn't apply when count=31 and width is 32.
