### PR TITLE
only return NVS error code if it is not OK

### DIFF
--- a/cpp_utils/CPPNVS.cpp
+++ b/cpp_utils/CPPNVS.cpp
@@ -74,12 +74,16 @@ int NVS::get(std::string key, std::string* result, bool isBlob) {
 	size_t length;
 	if (isBlob) {
 		esp_err_t rc = ::nvs_get_blob(m_handle, key.c_str(), NULL, &length);
-		ESP_LOGD(LOG_TAG, "Error getting key: %i", rc);
-		return rc;
+		if (rc != ESP_OK) {
+			ESP_LOGI(LOG_TAG, "Error getting key: %i", rc);
+			return rc;
+		}
 	} else {
 		esp_err_t rc = ::nvs_get_str(m_handle, key.c_str(), NULL, &length);
-		ESP_LOGD(LOG_TAG, "Error getting key: %i", rc);
-		return rc;
+		if (rc != ESP_OK) {
+			ESP_LOGI(LOG_TAG, "Error getting key: %i", rc);
+			return rc;
+		}
 	}
 	char *data = (char *)malloc(length);
 	if (isBlob) {


### PR DESCRIPTION
sorry about this, while my previous PR definitely fixed the crashing it also caused the NVS code to not actually get any values. This commit fixes it so that if it gets an error when doing the length check then it will return the error code it got from esp-idf otherwise continue normally.

Sorry I didn't see this the first time around and have introduced a bug, looking at the code now it's plainly obvious.