### PR TITLE
Replaced error message for double characteristics

### DIFF
--- a/cpp_utils/BLEService.cpp
+++ b/cpp_utils/BLEService.cpp
@@ -192,7 +192,7 @@ void BLEService::addCharacteristic(BLECharacteristic* pCharacteristic) {
 
 	// Check that we don't add the same characteristic twice.
 	if (m_characteristicMap.getByUUID(pCharacteristic->getUUID()) != nullptr) {
-		ESP_LOGE(LOG_TAG, "<< Attempt to add a characteristic but we already have one with this UUID");
+		ESP_LOGW(LOG_TAG, "<< Adding a new characteristic with the same UUID as a previous one");
 		//return;
 	}
 


### PR DESCRIPTION
Made the fix that @chegewara  proposed. I was confused by the error and found this github issue in the repository: [Issue](https://github.com/nkolban/esp32-snippets/issues/175). I changed the error to a warning, because it actually is possible to create multiple characteristics with the same UUID.