### PR TITLE
Modified bootWiFi2 method to call m_wifi.connectAP forever or until it successfully connects

### DIFF
--- a/cpp_utils/GeneralUtils.cpp
+++ b/cpp_utils/GeneralUtils.cpp
@@ -434,6 +434,82 @@ const char* GeneralUtils::errorToString(esp_err_t errCode) {
 	return "Unknown ESP_ERR error";
 } // errorToString
 
+/**
+ * @brief Convert a wifi_err_reason_t code to a string.
+ * @param [in] errCode The errCode to be converted.
+ * @return A string representation of the error code.
+ * 
+ * @note: wifi_err_reason_t values as of April 2018 are: (1-24, 200-204) and are defined in ~/esp-idf/components/esp32/include/esp_wifi_types.h.
+ */
+const char* GeneralUtils::wifiErrorToString(uint8_t errCode) {
+  if (errCode == ESP_OK)
+    return "ESP_OK (received SYSTEM_EVENT_STA_GOT_IP event)";
+  if (errCode == UINT8_MAX)
+    return "Not Connected (default value)";
+
+	switch((wifi_err_reason_t) errCode) {
+	case WIFI_REASON_UNSPECIFIED:
+		return "WIFI_REASON_UNSPECIFIED";
+	case WIFI_REASON_AUTH_EXPIRE:
+		return "WIFI_REASON_AUTH_EXPIRE";
+	case WIFI_REASON_AUTH_LEAVE:
+		return "WIFI_REASON_AUTH_LEAVE";
+	case WIFI_REASON_ASSOC_EXPIRE:
+		return "WIFI_REASON_ASSOC_EXPIRE";
+	case WIFI_REASON_ASSOC_TOOMANY:
+		return "WIFI_REASON_ASSOC_TOOMANY";
+	case WIFI_REASON_NOT_AUTHED:
+		return "WIFI_REASON_NOT_AUTHED";
+	case WIFI_REASON_NOT_ASSOCED:
+		return "WIFI_REASON_NOT_ASSOCED";
+	case WIFI_REASON_ASSOC_LEAVE:
+		return "WIFI_REASON_ASSOC_LEAVE";
+	case WIFI_REASON_ASSOC_NOT_AUTHED:
+		return "WIFI_REASON_ASSOC_NOT_AUTHED";
+	case WIFI_REASON_DISASSOC_PWRCAP_BAD:
+		return "WIFI_REASON_DISASSOC_PWRCAP_BAD";
+	case WIFI_REASON_DISASSOC_SUPCHAN_BAD:
+		return "WIFI_REASON_DISASSOC_SUPCHAN_BAD";
+	case WIFI_REASON_IE_INVALID:
+		return "WIFI_REASON_IE_INVALID";
+	case WIFI_REASON_MIC_FAILURE:
+		return "WIFI_REASON_MIC_FAILURE";
+	case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:
+		return "WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT";
+	case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT:
+		return "WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT";
+	case WIFI_REASON_IE_IN_4WAY_DIFFERS:
+		return "WIFI_REASON_IE_IN_4WAY_DIFFERS";
+	case WIFI_REASON_GROUP_CIPHER_INVALID:
+		return "WIFI_REASON_GROUP_CIPHER_INVALID";
+	case WIFI_REASON_PAIRWISE_CIPHER_INVALID:
+		return "WIFI_REASON_PAIRWISE_CIPHER_INVALID";
+	case WIFI_REASON_AKMP_INVALID:
+		return "WIFI_REASON_AKMP_INVALID";
+	case WIFI_REASON_UNSUPP_RSN_IE_VERSION:
+		return "WIFI_REASON_UNSUPP_RSN_IE_VERSION";
+	case WIFI_REASON_INVALID_RSN_IE_CAP:
+		return "WIFI_REASON_INVALID_RSN_IE_CAP";
+	case WIFI_REASON_802_1X_AUTH_FAILED:
+		return "WIFI_REASON_802_1X_AUTH_FAILED";
+	case WIFI_REASON_CIPHER_SUITE_REJECTED:
+		return "WIFI_REASON_CIPHER_SUITE_REJECTED";
+
+	case WIFI_REASON_BEACON_TIMEOUT:
+		return "WIFI_REASON_BEACON_TIMEOUT";
+	case WIFI_REASON_NO_AP_FOUND:
+		return "WIFI_REASON_NO_AP_FOUND";
+	case WIFI_REASON_AUTH_FAIL:
+		return "WIFI_REASON_AUTH_FAIL";
+	case WIFI_REASON_ASSOC_FAIL:
+		return "WIFI_REASON_ASSOC_FAIL";
+	case WIFI_REASON_HANDSHAKE_TIMEOUT:
+		return "WIFI_REASON_HANDSHAKE_TIMEOUT";
+	}
+	return "Unknown ESP_ERR error";
+} // wifiErrorToString
+
+
 
 /**
  * @brief Convert a string to lower case.

--- a/cpp_utils/GeneralUtils.h
+++ b/cpp_utils/GeneralUtils.h
@@ -23,6 +23,7 @@ public:
 	static void        dumpInfo();
 	static bool        endsWith(std::string str, char c);
 	static const char* errorToString(esp_err_t errCode);
+  static const char* wifiErrorToString(uint8_t value);
 	static void        hexDump(const uint8_t* pData, uint32_t length);
 	static std::string ipToString(uint8_t* ip);
 	static std::vector<std::string> split(std::string source, char delimiter);

--- a/cpp_utils/WiFi.cpp
+++ b/cpp_utils/WiFi.cpp
@@ -55,7 +55,7 @@ WiFi::WiFi()
 	m_eventLoopStarted  = false;
 	m_initCalled        = false;
 	//m_pWifiEventHandler = new WiFiEventHandler();
-	m_apConnected       = false;    // Are we connected to an access point?
+	m_apConnectionStatus       = UINT8_MAX;    // Are we connected to an access point?
 } // WiFi
 
 
@@ -153,12 +153,12 @@ void WiFi::setDNSServer(int numdns, ip_addr_t ip) {
  * @param [in] ssid The network SSID of the access point to which we wish to connect.
  * @param [in] password The password of the access point to which we wish to connect.
  * @param [in] waitForConnection Block until the connection has an outcome.
- * @return N/A.
+ * @returns ESP_OK if successfully connected to an access point.  Otherwise returns wifi_err_reason_t - use GeneralUtils::wifiErrorToString(uint8_t errCode) to print the error.
  */
-bool WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection){
+uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection){
 	ESP_LOGD(LOG_TAG, ">> connectAP");
 
-	m_apConnected = false;
+	m_apConnectionStatus = UINT8_MAX;
 	init();
 
 	if (ip != 0 && gw != 0 && netmask != 0) {
@@ -206,7 +206,7 @@ bool WiFi::connectAP(const std::string& ssid, const std::string& password, bool 
     m_connectFinished.give();
 
 	ESP_LOGD(LOG_TAG, "<< connectAP");
-	return m_apConnected;  // Return true if we are now connected and false if not.
+	return m_apConnectionStatus;  // Return ESP_OK if we are now connected and wifi_err_reason_t if not.
 } // connectAP
 
 
@@ -228,7 +228,7 @@ void WiFi::dump() {
  * @brief Returns whether wifi is connected to an access point
  */
 bool WiFi::isConnectedToAP() {
-	return m_apConnected;
+	return m_apConnectionStatus;
 } // isConnected
 
 
@@ -255,10 +255,11 @@ bool WiFi::isConnectedToAP() {
 	// If the event we received indicates that we now have an IP address or that a connection was disconnected then unlock the mutex that
 	// indicates we are waiting for a connection complete.
 	if (event->event_id == SYSTEM_EVENT_STA_GOT_IP || event->event_id == SYSTEM_EVENT_STA_DISCONNECTED) {
-		if (event->event_id == SYSTEM_EVENT_STA_GOT_IP) {  // If we connected and have an IP, change the flag.
-			pWiFi->m_apConnected = true;
+
+		if (event->event_id == SYSTEM_EVENT_STA_GOT_IP) {  // If we connected and have an IP, change the status to ESP_OK.  Otherwise, change it to the reason code.
+			pWiFi->m_apConnectionStatus = ESP_OK;
 		} else {
-			pWiFi->m_apConnected = false;
+			pWiFi->m_apConnectionStatus = event->event_info.disconnected.reason;
 		}
 		pWiFi->m_connectFinished.give();
 	}

--- a/cpp_utils/WiFi.cpp
+++ b/cpp_utils/WiFi.cpp
@@ -153,7 +153,7 @@ void WiFi::setDNSServer(int numdns, ip_addr_t ip) {
  * @param [in] ssid The network SSID of the access point to which we wish to connect.
  * @param [in] password The password of the access point to which we wish to connect.
  * @param [in] waitForConnection Block until the connection has an outcome.
- * @returns ESP_OK if successfully connected to an access point.  Otherwise returns wifi_err_reason_t - use GeneralUtils::wifiErrorToString(uint8_t errCode) to print the error.
+ * @returns ESP_OK if successfully receives a SYSTEM_EVENT_STA_GOT_IP event.  Otherwise returns wifi_err_reason_t - use GeneralUtils::wifiErrorToString(uint8_t errCode) to print the error.
  */
 uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection){
 	ESP_LOGD(LOG_TAG, ">> connectAP");

--- a/cpp_utils/WiFi.h
+++ b/cpp_utils/WiFi.h
@@ -116,7 +116,7 @@ private:
     uint8_t             m_dnsCount=0;
     bool                m_eventLoopStarted;
     bool                m_initCalled;
-    bool                m_apConnected;   // Are we connected to an access point?
+    uint8_t             m_apConnectionStatus;   // ESP_OK = we are connected to an access point.  Otherwise receives wifi_err_reason_t.
   	FreeRTOS::Semaphore m_connectFinished = FreeRTOS::Semaphore("ConnectFinished");
 
 public:
@@ -130,7 +130,7 @@ public:
     void                      setDNSServer(int numdns, ip_addr_t ip);
     struct in_addr            getHostByName(const std::string& hostName);
     struct in_addr            getHostByName(const char* hostName);
-    bool                      connectAP(const std::string& ssid, const std::string& password, bool waitForConnection=true);
+    uint8_t                   connectAP(const std::string& ssid, const std::string& password, bool waitForConnection=true);
     void                      dump();
     bool                      isConnectedToAP();
     static std::string        getApMac();

--- a/networking/bootwifi/BootWiFi.cpp
+++ b/networking/bootwifi/BootWiFi.cpp
@@ -285,7 +285,11 @@ void BootWiFi::bootWiFi2() {
 		 		connectionInfo.ipInfo.gw.addr,
 				connectionInfo.ipInfo.netmask.addr
 			);
-		  m_wifi.connectAP(connectionInfo.ssid, connectionInfo.password);   // Connect to the access point.
+		  
+      // Connect to the access point.
+      while(!m_wifi.connectAP(connectionInfo.ssid, connectionInfo.password)){
+        ESP_LOGE(LOG_TAG, "Unable to connect to access point \"%s\" - trying again...", connectionInfo.ssid);
+      };   
 
 		} else {
 			// We do NOT have connection information.  Let us now become an access


### PR DESCRIPTION
Prior to this change, `bootWiFi2` would sometimes return before the ESP32 had successfully connected to WiFi - specifically when a `staDisconnected` event was received.  

This causes `BootWiFi::boot()` to hang, waiting indefinitely on `m_completeSemaphore.wait("boot");`.  This happens because the only place the semaphore is resolved is in the `staGotIp` event handler.  Unfortunately, the `staGotIp`event never occurs because bootWiFi2 has returned and so there are no retry attempts.

This change ensures that ESP32 has successfully connected before BootWiFi returns (or keeps trying forever).