### PR TITLE
Typo fixes

### DIFF
--- a/cpp_utils/BLEServer.cpp
+++ b/cpp_utils/BLEServer.cpp
@@ -18,7 +18,6 @@
 #include "BLEUtils.h"
 #include <string.h>
 #include <string>
-#include <gatt_api.h>
 #include <unordered_set>
 #ifdef ARDUINO_ARCH_ESP32
 #include "esp32-hal-log.h"

--- a/cpp_utils/PubSubClient.cpp
+++ b/cpp_utils/PubSubClient.cpp
@@ -315,7 +315,7 @@ bool PubSubClient::connect(){
 
 		ESP_LOGD(TAG, "Connect to mqtt server...");
 
-		ESP_LOGD(TAG, "ip: %s  port: %d", _config.ip.c_str(), _config.port)
+		ESP_LOGD(TAG, "ip: %s  port: %d", _config.ip.c_str(), _config.port);
 		int result = _client->connect((char *)_config.ip.c_str(), _config.port);
 
 		if (result == 0) {

--- a/cpp_utils/SockServ.cpp
+++ b/cpp_utils/SockServ.cpp
@@ -64,7 +64,7 @@ SockServ::~SockServ() {
 	SockServ* pSockServ = (SockServ*)data;
 	try {
 		while(1) {
-			ESP_LOGD(LOG_TAG, "Waiting on accept")
+			ESP_LOGD(LOG_TAG, "Waiting on accept");
 			Socket tempSock = pSockServ->m_serverSocket.accept();
 			if (!tempSock.isValid()) {
 				continue;
@@ -229,7 +229,7 @@ Socket SockServ::waitForData(std::set<Socket>& socketSet) {
  * or can return immediately is there is already a client connection in existence.
  */
 Socket SockServ::waitForNewClient() {
-	ESP_LOGD(LOG_TAG, ">> waitForNewClient")
+	ESP_LOGD(LOG_TAG, ">> waitForNewClient");
 	m_clientSemaphore.wait("waitForNewClient");                 // Unlocked in acceptTask.
 	m_clientSemaphore.take("waitForNewClient");
 	Socket tempSocket;


### PR DESCRIPTION
Added three missing semi-colons.
Removed unecessary header (gatt_api.h). For some reason, with latest esp-idf, my toolchain can't resolve this header location. Anyway, the header is not required by BLEServer.cpp.
