### PR TITLE
Removed vTaskDelete, avoiding crashes with Task::stop() called

### DIFF
--- a/cpp_utils/tests/BLETests/SampleHIDKeyboard.cpp
+++ b/cpp_utils/tests/BLETests/SampleHIDKeyboard.cpp
@@ -59,7 +59,6 @@ class MyTask : public Task {
 			}
         	vTaskDelay(2000/portTICK_PERIOD_MS); // simulate write message every 2 seconds
     	}
-		vTaskDelete(NULL);
 	}
 };
 


### PR DESCRIPTION
via the callback for onDisconnect, the keyboard task is stopped.
It seems, that in addition, the task itself deletes itself again via ::vTaskDelete(NULL).

This leads to a crash by dereferencing the already missing TCB.

Used example: https://github.com/asterics/esp32_mouse_keyboard/tree/newBLE

```

I (757) HAL_BLE: Advertising started!
--- debug messages added to Task::start()---
I (2327) task: start, m_handle before: 0
I (2327) task: start, m_handle after: 3FFE6EB8
I (2327) task: start, m_handle before: 0
I (2337) task: start, m_handle after: 3FFE8FC4
E (2427) BT: Call back not found for application conn_id=3
I (2427) BLEDevice: ESP_GATTS_MTU_EVT, MTU 517
I (2447) HAL_BLE: special keys: 1

...... BLE sending keyboard & mouse .....

Disabling BLE on Win10 (and Android):

I (38337) HAL_BLE: Sending mouse report: 
I (38337) HAL_BLE: 0x3ffe8f00   00 ce ce 00                                       |....|
E (38577) BT: bta_gattc_conn_cback() - cif=3 connected=0 conn_id=3 reason=0x0015
--- debug messages added to Task::stop()---
I (38577) task: m_handle: 3FFE6EB8
I (38577) task: m_handle: 0, temp: 3FFE6EB8
Guru Meditation Error: Core  0 panic'ed (LoadProhibited)
. Exception was unhandled.
Core 0 register dump:
PC      : 0x4008b9db  PS      : 0x00060633  A0      : 0x8008a9f3  A1      : 0x3ffdacf0  
0x4008b9db: uxListRemove at /home/XX/esp/esp-idf/components/freertos/list.c:218

A2      : 0x3ffe6ec0  A3      : 0x00000000  A4      : 0x3ffdace0  A5      : 0x0000000c  
A6      : 0x00000001  A7      : 0x00000000  A8      : 0x00000000  A9      : 0x3ffc3ae4  
A10     : 0x3ffc3ae4  A11     : 0x00060620  A12     : 0x00000000  A13     : 0x00000001  
A14     : 0x0000cdcd  A15     : 0x00000004  SAR     : 0x00000004  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000004  LBEG    : 0x400014fd  LEND    : 0x4000150d  LCOUNT  : 0xfffffffe  

Backtrace: 0x4008b9db:0x3ffdacf0 0x4008a9f0:0x3ffdad10 0x400e3cc3:0x3ffdad30 0x400e1e45:0x3ffdad60 0x400e26d4:0x3ffdad80 0x400e3f85:0x3ffdadc0 0x4010c456:0x3ffdade0 0x4010cfad:0x3ffdae00 0x40108cc6:0x3ffdae40
0x4008b9db: uxListRemove at /home/XX/esp/esp-idf/components/freertos/list.c:218

0x4008a9f0: vTaskDelete at /home/XX/esp/esp-idf/components/freertos/tasks.c:4574

0x400e3cc3: Task::stop() at /home/XX/esp/esp32_mouse_keyboard/components/nkolban_BLE/Task.cpp:95 (discriminator 8)

0x400e1e45: CBs::onDisconnect(BLEServer*) at /home/XX/esp/esp32_mouse_keyboard/components/nkolban_BLE/HID_kbdmousejoystick.cpp:195

0x400e26d4: BLEServer::handleGATTServerEvent(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at /home/XX/esp/esptoolchain/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/5.2.0/bits/basic_string.h:544

0x400e3f85: BLEDevice::gattServerEventHandler(esp_gatts_cb_event_t, unsigned char, esp_ble_gatts_cb_param_t*) at /home/XX/esp/esp32_mouse_keyboard/components/nkolban_BLE/BLEDevice.cpp:522 (discriminator 1)

0x4010c456: btc_gatts_cb_to_app at /home/XX/esp/esp-idf/components/bt/bluedroid/btc/profile/std/gatt/btc_gatts.c:482

0x4010cfad: btc_gatts_cb_handler at /home/XX/esp/esp-idf/components/bt/bluedroid/btc/profile/std/gatt/btc_gatts.c:910

0x40108cc6: btc_task at /home/XX/esp/esp-idf/components/bt/bluedroid/btc/core/btc_task.c:104
```