### PR TITLE
BLE_UART example: Add Service UUID advertising (iOS support)

### DIFF
--- a/cpp_utils/tests/BLETests/Arduino/BLE_uart/BLE_uart.ino
+++ b/cpp_utils/tests/BLETests/Arduino/BLE_uart/BLE_uart.ino
@@ -97,6 +97,7 @@ void setup() {
   pService->start();
 
   // Start advertising
+  pServer->getAdvertising()->addServiceUUID(pService->getUUID());
   pServer->getAdvertising()->start();
   Serial.println("Waiting a client connection to notify...");
 }


### PR DESCRIPTION
Lots of apps (e.g. Blynk, RemoteXY) do not find the device during scanning on iOS, whereas other devices with the same service UUID are found. The origin of the problem is that in the advertisment, the service UUID is missing. This extra line fixes this problem.