### PR TITLE
Set spi_bus_config_t and spi_device_interface_config_t flags

### DIFF
--- a/cpp_utils/SPI.cpp
+++ b/cpp_utils/SPI.cpp
@@ -54,6 +54,7 @@ void SPI::init(int mosiPin, int misoPin, int clkPin, int csPin) {
 	bus_config.quadwp_io_num   = -1;      // Not used
 	bus_config.quadhd_io_num   = -1;      // Not used
 	bus_config.max_transfer_sz = 0;       // 0 means use default.
+    bus_config.flags           = (SPICOMMON_BUSFLAG_SCLK | SPICOMMON_BUSFLAG_MOSI | SPICOMMON_BUSFLAG_MISO);
 
 	ESP_LOGI(LOG_TAG, "... Initializing bus; host=%d", m_host);
 
@@ -78,7 +79,7 @@ void SPI::init(int mosiPin, int misoPin, int clkPin, int csPin) {
 	dev_config.cs_ena_pretrans  = 0;
 	dev_config.clock_speed_hz   = 100000;
 	dev_config.spics_io_num     = csPin;
-	dev_config.flags            = 0;
+	dev_config.flags            = SPI_DEVICE_NO_DUMMY;
 	dev_config.queue_size       = 1;
 	dev_config.pre_cb           = NULL;
 	dev_config.post_cb          = NULL;


### PR DESCRIPTION
In `SPI::init` the missing initialization of `bus_config.flags` resulted in a boot failure and the message "spiwp pin required." from `spicommon_bus_initialize_io` in spi_common.c.

Similarly the dev_config.flags now needs to be initialized to prevent a boot failure and corresponding message from `spi_bus_add_device` in spi_master.c.


See also #485 