### PR TITLE
BLE Remove Service Support

### DIFF
--- a/cpp_utils/BLEServer.cpp
+++ b/cpp_utils/BLEServer.cpp
@@ -323,6 +323,14 @@ void BLEServer::setCallbacks(BLEServerCallbacks* pCallbacks) {
 	m_pServerCallbacks = pCallbacks;
 } // setCallbacks
 
+/*
+ * Remove service
+ */
+void BLEServer::removeService(BLEService *service) {
+	service->stop();
+	service->executeDelete();	
+	m_serviceMap.removeService(service);
+}
 
 /**
  * @brief Start advertising.

--- a/cpp_utils/BLEServer.h
+++ b/cpp_utils/BLEServer.h
@@ -42,6 +42,7 @@ public:
 	std::string toString();
 	BLEService* getFirst();
 	BLEService* getNext();
+	void 		removeService(BLEService *service);
 
 private:
 	std::map<uint16_t, BLEService*>    m_handleMap;
@@ -61,6 +62,7 @@ public:
 	BLEAdvertising* getAdvertising();
 	void            setCallbacks(BLEServerCallbacks* pCallbacks);
 	void            startAdvertising();
+	void 			removeService(BLEService *service);
 
 
 private:

--- a/cpp_utils/BLEService.cpp
+++ b/cpp_utils/BLEService.cpp
@@ -92,6 +92,29 @@ void BLEService::executeCreate(BLEServer *pServer) {
 
 
 /**
+ * @brief Delete the service.
+ * Delete the service.
+ * @param [in] gatts_if The handle of the GATT server interface.
+ * @return N/A.
+ */
+
+void BLEService::executeDelete() {
+	ESP_LOGD(LOG_TAG, ">> executeDelete()");
+	m_semaphoreDeleteEvt.take("executeDelete"); // Take the mutex and release at event ESP_GATTS_CREATE_EVT
+
+	esp_err_t errRc = ::esp_ble_gatts_delete_service( getHandle() );
+
+	if (errRc != ESP_OK) {
+		ESP_LOGE(LOG_TAG, "esp_ble_gatts_delete_service: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
+		return;
+	}
+
+	m_semaphoreDeleteEvt.wait("executeDelete");
+	ESP_LOGD(LOG_TAG, "<< executeDelete");
+} // executeDelete
+
+
+/**
  * @brief Dump details of this BLE GATT service.
  * @return N/A.
  */
@@ -150,6 +173,34 @@ void BLEService::start() {
 	m_semaphoreStartEvt.wait("start");
 
 	ESP_LOGD(LOG_TAG, "<< start()");
+} // start
+
+
+/**
+ * @brief Stop the service.
+ * @return Stop the service.
+ */
+void BLEService::stop() {
+// We ask the BLE runtime to start the service and then create each of the characteristics.
+// We start the service through its local handle which was returned in the ESP_GATTS_CREATE_EVT event
+// obtained as a result of calling esp_ble_gatts_create_service().
+//
+	ESP_LOGD(LOG_TAG, ">> stop(): Stopping service (esp_ble_gatts_stop_service): %s", toString().c_str());
+	if (m_handle == NULL_HANDLE) {
+		ESP_LOGE(LOG_TAG, "<< !!! We attempted to stop a service but don't know its handle!");
+		return;
+	}
+
+	m_semaphoreStopEvt.take("stop");
+	esp_err_t errRc = ::esp_ble_gatts_stop_service(m_handle);
+
+	if (errRc != ESP_OK) {
+		ESP_LOGE(LOG_TAG, "<< esp_ble_gatts_stop_service: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
+		return;
+	}
+	m_semaphoreStopEvt.wait("stop");
+
+	ESP_LOGD(LOG_TAG, "<< stop()");
 } // start
 
 
@@ -278,6 +329,10 @@ void BLEService::handleGATTServerEvent(
 			break;
 		} // ESP_GATTS_START_EVT
 
+		case ESP_GATTS_STOP_EVT:
+			m_semaphoreStopEvt.give();
+			break;
+
 
 		// ESP_GATTS_CREATE_EVT
 		// Called when a new service is registered as having been created.
@@ -298,6 +353,11 @@ void BLEService::handleGATTServerEvent(
 			}
 			break;
 		} // ESP_GATTS_CREATE_EVT
+
+		case ESP_GATTS_DELETE_EVT: {
+			m_semaphoreDeleteEvt.give();
+			break;
+		}
 
 		default: {
 			break;

--- a/cpp_utils/BLEService.h
+++ b/cpp_utils/BLEService.h
@@ -57,11 +57,13 @@ public:
 	BLECharacteristic* createCharacteristic(BLEUUID uuid, uint32_t properties);
 	void               dump();
 	void               executeCreate(BLEServer* pServer);
+	void			   executeDelete();
 	BLECharacteristic* getCharacteristic(const char* uuid);
 	BLECharacteristic* getCharacteristic(BLEUUID uuid);
 	BLEUUID            getUUID();
 	BLEServer*         getServer();
 	void               start();
+	void			   stop();
 	std::string        toString();
 	uint16_t           getHandle();
 	uint8_t			   m_id = 0;
@@ -82,7 +84,9 @@ private:
 	BLEUUID              m_uuid;
 
 	FreeRTOS::Semaphore  m_semaphoreCreateEvt = FreeRTOS::Semaphore("CreateEvt");
+	FreeRTOS::Semaphore  m_semaphoreDeleteEvt = FreeRTOS::Semaphore("DeleteEvt");
 	FreeRTOS::Semaphore  m_semaphoreStartEvt  = FreeRTOS::Semaphore("StartEvt");
+	FreeRTOS::Semaphore  m_semaphoreStopEvt   = FreeRTOS::Semaphore("StopEvt");
 
 	uint32_t             m_numHandles;
 

--- a/cpp_utils/BLEServiceMap.cpp
+++ b/cpp_utils/BLEServiceMap.cpp
@@ -120,4 +120,9 @@ BLEService* BLEServiceMap::getNext() {
 	return pRet;
 } // getNext
 
+void BLEServiceMap::removeService(BLEService *service){
+	m_handleMap.erase(service->getHandle());
+	m_uuidMap.erase(service);
+}
+
 #endif /* CONFIG_BT_ENABLED */

--- a/cpp_utils/BLEServiceMap.cpp
+++ b/cpp_utils/BLEServiceMap.cpp
@@ -120,9 +120,13 @@ BLEService* BLEServiceMap::getNext() {
 	return pRet;
 } // getNext
 
+/**
+ * @brief Removes service from maps.
+ * @return N/A.
+ */
 void BLEServiceMap::removeService(BLEService *service){
 	m_handleMap.erase(service->getHandle());
 	m_uuidMap.erase(service);
-}
+} // removeService
 
 #endif /* CONFIG_BT_ENABLED */


### PR DESCRIPTION
Changes in relation to #534 .

To remove a service call `removeService` method on BLEServer object with the service you want to remove.