### PR TITLE
Option to choose WIFI_MODE_APSTA when connecting to an AP

### DIFF
--- a/cpp_utils/WiFi.cpp
+++ b/cpp_utils/WiFi.cpp
@@ -146,16 +146,24 @@ void WiFi::setDNSServer(int numdns, ip_addr_t ip) {
 
 
 /**
- * @brief Connect to an external access point.
+ * @see WiFi::connectWithMode - this one defaults the mode to WIFI_MODE_AP
+ */
+uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection){
+	return this->connectWithMode(ssid, password, waitForConnection, WIFI_MODE_AP);
+}
+
+/**
+ * @brief Connect to an external access point and specify the mode (WIFI_MODE_AP or WIFI_MODE_APSTA).
  *
  * The event handler will be called back with the outcome of the connection.
  *
  * @param [in] ssid The network SSID of the access point to which we wish to connect.
  * @param [in] password The password of the access point to which we wish to connect.
  * @param [in] waitForConnection Block until the connection has an outcome.
- * @returns ESP_OK if successfully receives a SYSTEM_EVENT_STA_GOT_IP event.  Otherwise returns wifi_err_reason_t - use GeneralUtils::wifiErrorToString(uint8_t errCode) to print the error.
+ * @param [in] mode WIFI_MODE_AP for normal or WIFI_MODE_APSTA if you want to keep an Access Point running while you connect
+ * @return N/A.
  */
-uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection){
+uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection, wifi_mode_t mode){
 	ESP_LOGD(LOG_TAG, ">> connectAP");
 
 	m_apConnectionStatus = UINT8_MAX;
@@ -172,7 +180,7 @@ uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bo
 			::tcpip_adapter_set_ip_info(TCPIP_ADAPTER_IF_STA, &ipInfo);
 	}
 
-	esp_err_t errRc = ::esp_wifi_set_mode(WIFI_MODE_STA);
+	esp_err_t errRc = ::esp_wifi_set_mode(mode);
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "esp_wifi_set_mode: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 		abort();

--- a/cpp_utils/WiFi.cpp
+++ b/cpp_utils/WiFi.cpp
@@ -146,7 +146,7 @@ void WiFi::setDNSServer(int numdns, ip_addr_t ip) {
 
 
 /**
- * @brief Connect to an external access point and specify the mode (WIFI_MODE_AP or WIFI_MODE_APSTA).
+ * @brief Connect to an external access point.
  *
  * The event handler will be called back with the outcome of the connection.
  *
@@ -154,7 +154,7 @@ void WiFi::setDNSServer(int numdns, ip_addr_t ip) {
  * @param [in] password The password of the access point to which we wish to connect.
  * @param [in] waitForConnection Block until the connection has an outcome.
  * @param [in] mode WIFI_MODE_AP for normal or WIFI_MODE_APSTA if you want to keep an Access Point running while you connect
- * @return N/A.
+ * @return ESP_OK if we are now connected and wifi_err_reason_t if not.
  */
 uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection, wifi_mode_t mode){
 	ESP_LOGD(LOG_TAG, ">> connectAP");

--- a/cpp_utils/WiFi.cpp
+++ b/cpp_utils/WiFi.cpp
@@ -146,13 +146,6 @@ void WiFi::setDNSServer(int numdns, ip_addr_t ip) {
 
 
 /**
- * @see WiFi::connectWithMode - this one defaults the mode to WIFI_MODE_AP
- */
-uint8_t WiFi::connectAP(const std::string& ssid, const std::string& password, bool waitForConnection){
-	return this->connectWithMode(ssid, password, waitForConnection, WIFI_MODE_AP);
-}
-
-/**
  * @brief Connect to an external access point and specify the mode (WIFI_MODE_AP or WIFI_MODE_APSTA).
  *
  * The event handler will be called back with the outcome of the connection.

--- a/cpp_utils/WiFi.h
+++ b/cpp_utils/WiFi.h
@@ -131,6 +131,7 @@ public:
     struct in_addr            getHostByName(const std::string& hostName);
     struct in_addr            getHostByName(const char* hostName);
     uint8_t                   connectAP(const std::string& ssid, const std::string& password, bool waitForConnection=true);
+    uint8_t                   connectWithMode(const std::string& ssid, const std::string& password, bool waitForConnection, wifi_mode_t mode);
     void                      dump();
     bool                      isConnectedToAP();
     static std::string        getApMac();

--- a/cpp_utils/WiFi.h
+++ b/cpp_utils/WiFi.h
@@ -130,8 +130,7 @@ public:
     void                      setDNSServer(int numdns, ip_addr_t ip);
     struct in_addr            getHostByName(const std::string& hostName);
     struct in_addr            getHostByName(const char* hostName);
-    uint8_t                   connectAP(const std::string& ssid, const std::string& password, bool waitForConnection=true);
-    uint8_t                   connectWithMode(const std::string& ssid, const std::string& password, bool waitForConnection, wifi_mode_t mode);
+    uint8_t                   connectAP(const std::string& ssid, const std::string& password, bool waitForConnection=true, wifi_mode_t mode=WIFI_MODE_STA);
     void                      dump();
     bool                      isConnectedToAP();
     static std::string        getApMac();


### PR DESCRIPTION
I made this change because I needed a way to keep the esp32's own Access Point running while it connected to a remote AP. 

I've tested this change with an older version of esp32-snippets (when connectAP still returned bool) but apart from the return type the function appears to be the same.

Once I get my current feature sorted out I'm planning to upgrade to master so I will test it then, but it seemed like a small change so might as well raise a PR at least for discussion.