### PR TITLE
FIX: BLESecurity.h -> BLESecurityCallbacks.

### DIFF
--- a/cpp_utils/BLESecurity.h
+++ b/cpp_utils/BLESecurity.h
@@ -51,20 +51,20 @@ public:
 	 * It requires that our device is capable to display this code to end user
 	 * @param
 	 */
-	virtual void onPassKeyNotify(uint32_t pass_key);
+	virtual void onPassKeyNotify(uint32_t pass_key) = 0;
 
 	/**
 	 * @brief Here we can make decision if we want to let negotiate authorization with peer device or not
 	 * return Return true if we accept this peer device request
 	 */
 
-	virtual bool onSecurityRequest();
+	virtual bool onSecurityRequest() = 0 ;
 	/**
 	 * Provide us information when authentication process is completed
 	 */
-	virtual void onAuthenticationComplete(esp_ble_auth_cmpl_t);
+	virtual void onAuthenticationComplete(esp_ble_auth_cmpl_t) = 0;
 
-	virtual bool onConfirmPIN(uint32_t pin);
+	virtual bool onConfirmPIN(uint32_t pin) = 0;
 }; // BLESecurityCallbacks
 
 #endif // CONFIG_BT_ENABLED


### PR DESCRIPTION
Make all the methods pure virtual.
Some of the methods were virtual, but without local definitions,
this creates an error during linking.

I think there shouldn't be any default behavior for this class.

This will fix issue #412 