### PR TITLE
Handle `response` argument for BLERemoteDescriptor#writeValue()

### DIFF
--- a/cpp_utils/BLERemoteDescriptor.cpp
+++ b/cpp_utils/BLERemoteDescriptor.cpp
@@ -148,7 +148,7 @@ void BLERemoteDescriptor::writeValue(
 		getHandle(),
 		length,                           // Data length
 		data,                             // Data
-		ESP_GATT_WRITE_TYPE_NO_RSP,
+		response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP,
 		ESP_GATT_AUTH_REQ_NONE
 	);
 	if (errRc != ESP_OK) {


### PR DESCRIPTION
I initially issued nkolban/ESP32_BLE_Arduino#17 but was told ([here](https://github.com/nkolban/esp32-snippets/issues/391#issuecomment-402993009)) that this is the master repo, hence this PR :D 