### PR TITLE
Bug fix for cpp_utils/tests/task_i2c_scanner.cpp

### DIFF
--- a/cpp_utils/tests/task_i2c_scanner.cpp
+++ b/cpp_utils/tests/task_i2c_scanner.cpp
@@ -6,6 +6,7 @@
 
 #include "sdkconfig.h"
 
+#define DEVICE_ADDRESS 0
 #define SDA_PIN 25
 #define SCL_PIN 26
 
@@ -14,7 +15,7 @@
 class I2CScanner: public Task {
 	void run(void *data) override {
 		I2C i2c;
-		i2c.init((gpio_num_t)SDA_PIN, (gpio_num_t)SCL_PIN);
+		i2c.init((uint8_t)DEVICE_ADDRESS, (gpio_num_t)SDA_PIN, (gpio_num_t)SCL_PIN);
 		i2c.scan();
 	} // End run
 };


### PR DESCRIPTION
Fix params passed to i2c.init() to include DEVICE_ADDRESS in the first position. Otherwise SDA becomes SCL_PIN and SCL becomes Default.

(I think I've got this right, but couldn't force compilation on the standalone branch, only as part of the components folder in another ESP32 project).