### PR TITLE
Fix  a bug in U8G2 HAL SPI initialize

### DIFF
--- a/hardware/displays/U8G2/u8g2_esp32_hal.c
+++ b/hardware/displays/U8G2/u8g2_esp32_hal.c
@@ -47,6 +47,7 @@ uint8_t u8g2_esp32_spi_byte_cb(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void 
 			}
 
 		  spi_bus_config_t bus_config;
+                  memset(&bus_config, 0, sizeof(spi_bus_config_t));
 		  bus_config.sclk_io_num   = u8g2_esp32_hal.clk; // CLK
 		  bus_config.mosi_io_num   = u8g2_esp32_hal.mosi; // MOSI
 		  bus_config.miso_io_num   = -1; // MISO


### PR DESCRIPTION
if we don't set bus_config to all zero, a wrong bus_config.flag may have some random bug