### PR TITLE
add `getData` proxy to BLECharacteristic

### DIFF
--- a/cpp_utils/BLECharacteristic.cpp
+++ b/cpp_utils/BLECharacteristic.cpp
@@ -198,6 +198,14 @@ std::string BLECharacteristic::getValue() {
 	return m_value.getValue();
 } // getValue
 
+/**
+ * @brief Retrieve the current raw data of the characteristic.
+ * @return A pointer to storage containing the current characteristic data.
+ */
+uint8_t* BLECharacteristic::getData() {
+	return m_value.getData();
+} // getData
+
 
 /**
  * Handle a GATT server event.

--- a/cpp_utils/BLECharacteristic.h
+++ b/cpp_utils/BLECharacteristic.h
@@ -65,6 +65,7 @@ public:
 	//size_t         getLength();
 	BLEUUID        getUUID();
 	std::string    getValue();
+	uint8_t*       getData();
 
 	void indicate();
 	void notify();


### PR DESCRIPTION
hi there,

for a year i was using `getValue().c_str()` to get raw characteristic value to pass to C function in couple of my applications.

It turns out raw `uint8_t` pointer to data already exists and implemented. I just added proper proxy functions to make them available in arduino and ease development a bit :)