### PR TITLE
Sanitize Neopixel logging

### DIFF
--- a/cpp_utils/NeoPixelWiFiEventHandler.cpp
+++ b/cpp_utils/NeoPixelWiFiEventHandler.cpp
@@ -5,7 +5,10 @@
  *      Author: kolban
  */
 #include <stdio.h>
+#include <esp_log.h>
 #include "NeoPixelWiFiEventHandler.h"
+
+static const char* LOG_TAG = "NeoPixelWiFiEventHandler";
 
 NeoPixelWiFiEventHandler::NeoPixelWiFiEventHandler(gpio_num_t gpioPin) {
 	this->gpioPin = gpioPin;
@@ -17,42 +20,42 @@ NeoPixelWiFiEventHandler::~NeoPixelWiFiEventHandler() {
 }
 
 esp_err_t NeoPixelWiFiEventHandler::apStart() {
-	printf("XXX apStart\n");
+	ESP_LOGD(LOG_TAG, "XXX apStart");
 	ws2812->setPixel(0, 0, 00, 64);
 	ws2812->show();
 	return ESP_OK;
 }
 
 esp_err_t NeoPixelWiFiEventHandler::staConnected(system_event_sta_connected_t info) {
-	printf("XXX staConnected\n");
+	ESP_LOGD(LOG_TAG, "XXX staConnected");
 	ws2812->setPixel(0, 57, 89, 66);
 	ws2812->show();
 	return ESP_OK;
 }
 
 esp_err_t NeoPixelWiFiEventHandler::staDisconnected(system_event_sta_disconnected_t info) {
-	printf("XXX staDisconnected\n");
+	ESP_LOGD(LOG_TAG, "XXX staDisconnected");
 	ws2812->setPixel(0, 64, 0, 0);
 	ws2812->show();
 	return ESP_OK;
 }
 
 esp_err_t NeoPixelWiFiEventHandler::staStart() {
-	printf("XXX staStart\n");
+	ESP_LOGD(LOG_TAG, "XXX staStart");
 	ws2812->setPixel(0, 64, 64, 0);
 	ws2812->show();
 	return ESP_OK;
 }
 
 esp_err_t NeoPixelWiFiEventHandler::staGotIp(system_event_sta_got_ip_t info) {
-	printf("XXX staGotIp\n");
+	ESP_LOGD(LOG_TAG, "XXX staGotIp");
 	ws2812->setPixel(0, 0, 64, 0);
 	ws2812->show();
 	return ESP_OK;
 }
 
 esp_err_t NeoPixelWiFiEventHandler::wifiReady() {
-	printf("XXX wifiReady\n");
+	ESP_LOGD(LOG_TAG, "XXX wifiReady");
 	ws2812->setPixel(0, 64, 64, 0);
 	ws2812->show();
 	return ESP_OK;


### PR DESCRIPTION
Neopixel event handler seems to be using sprintf for logging purposes. This ignores the minimum level set for logging in config (also I'm not sure if that'd even work).