### PR TITLE
BT: uint16_t numHandles

### DIFF
--- a/cpp_utils/BLEService.cpp
+++ b/cpp_utils/BLEService.cpp
@@ -35,7 +35,7 @@ static const char* LOG_TAG = "BLEService"; // Tag for logging.
  * @param [in] uuid The UUID of the service.
  * @param [in] numHandles The maximum number of handles associated with the service.
  */
-BLEService::BLEService(const char* uuid, uint32_t numHandles) : BLEService(BLEUUID(uuid), numHandles) {
+BLEService::BLEService(const char* uuid, uint16_t numHandles) : BLEService(BLEUUID(uuid), numHandles) {
 }
 
 
@@ -44,7 +44,7 @@ BLEService::BLEService(const char* uuid, uint32_t numHandles) : BLEService(BLEUU
  * @param [in] uuid The UUID of the service.
  * @param [in] numHandles The maximum number of handles associated with the service.
  */
-BLEService::BLEService(BLEUUID uuid, uint32_t numHandles) {
+BLEService::BLEService(BLEUUID uuid, uint16_t numHandles) {
 	m_uuid      = uuid;
 	m_handle    = NULL_HANDLE;
 	m_pServer   = nullptr;
@@ -264,7 +264,7 @@ void BLEService::addCharacteristic(BLECharacteristic* pCharacteristic) {
 BLECharacteristic* BLEService::createCharacteristic(const char* uuid, uint32_t properties) {
 	return createCharacteristic(BLEUUID(uuid), properties);
 }
-	
+
 
 /**
  * @brief Create a new BLE Characteristic associated with this service.

--- a/cpp_utils/BLEService.h
+++ b/cpp_utils/BLEService.h
@@ -27,7 +27,7 @@ public:
 	void setByUUID(BLECharacteristic* pCharacteristic, const char* uuid);
 	void setByUUID(BLECharacteristic* pCharacteristic, BLEUUID uuid);
 	void setByHandle(uint16_t handle, BLECharacteristic* pCharacteristic);
-	BLECharacteristic* getByUUID(const char* uuid);	
+	BLECharacteristic* getByUUID(const char* uuid);
 	BLECharacteristic* getByUUID(BLEUUID uuid);
 	BLECharacteristic* getByHandle(uint16_t handle);
 	BLECharacteristic* getFirst();
@@ -69,8 +69,8 @@ public:
 	uint8_t			   m_id = 0;
 
 private:
-	BLEService(const char* uuid, uint32_t numHandles);
-	BLEService(BLEUUID uuid, uint32_t numHandles);
+	BLEService(const char* uuid, uint16_t numHandles);
+	BLEService(BLEUUID uuid, uint16_t numHandles);
 	friend class BLEServer;
 	friend class BLEServiceMap;
 	friend class BLEDescriptor;
@@ -88,7 +88,7 @@ private:
 	FreeRTOS::Semaphore  m_semaphoreStartEvt  = FreeRTOS::Semaphore("StartEvt");
 	FreeRTOS::Semaphore  m_semaphoreStopEvt   = FreeRTOS::Semaphore("StopEvt");
 
-	uint32_t             m_numHandles;
+	uint16_t             m_numHandles;
 
 	BLECharacteristic* getLastCreatedCharacteristic();
 	void               handleGATTServerEvent(


### PR DESCRIPTION
Last parameter for `esp_ble_gatts_create_service`, `num_handle`, is of type uint16_t. There's no point of having `m_numHandles` to be uint32_t.