### PR TITLE
Ringbuffer::send returns bool

### DIFF
--- a/cpp_utils/FreeRTOS.cpp
+++ b/cpp_utils/FreeRTOS.cpp
@@ -279,8 +279,8 @@ void Ringbuffer::returnItem(void* item) {
  * @param [in] wait How long to wait before giving up.  The default is to wait indefinitely.
  * @return
  */
-uint32_t Ringbuffer::send(void* data, size_t length, TickType_t wait) {
-	return ::xRingbufferSend(m_handle, data, length, wait);
+bool Ringbuffer::send(void* data, size_t length, TickType_t wait) {
+	return ::xRingbufferSend(m_handle, data, length, wait) == pdTRUE;
 } // send
 
 

--- a/cpp_utils/FreeRTOS.h
+++ b/cpp_utils/FreeRTOS.h
@@ -62,7 +62,7 @@ public:
 
 	void*    receive(size_t* size, TickType_t wait = portMAX_DELAY);
 	void     returnItem(void* item);
-	uint32_t send(void* data, size_t length, TickType_t wait = portMAX_DELAY);
+	bool     send(void* data, size_t length, TickType_t wait = portMAX_DELAY);
 private:
 	RingbufHandle_t m_handle;
 };


### PR DESCRIPTION
Return from `Ringbuffer::send` is of type `uint32_t`, where it should be `bool`, just like underlying function's result.