### PR TITLE
FreeRTOS: Stack size is uint32_t

### DIFF
--- a/cpp_utils/FreeRTOS.cpp
+++ b/cpp_utils/FreeRTOS.cpp
@@ -32,7 +32,7 @@ void FreeRTOS::sleep(uint32_t ms) {
  * @param[in] param An optional parameter to be passed to the started task.
  * @param[in] stackSize An optional paremeter supplying the size of the stack in which to run the task.
  */
-void FreeRTOS::startTask(void task(void*), std::string taskName, void *param, int stackSize) {
+void FreeRTOS::startTask(void task(void*), std::string taskName, void *param, uint32_t stackSize) {
 	::xTaskCreate(task, taskName.data(), stackSize, param, 5, NULL);
 } // startTask
 

--- a/cpp_utils/FreeRTOS.h
+++ b/cpp_utils/FreeRTOS.h
@@ -23,7 +23,7 @@
 class FreeRTOS {
 public:
 	static void sleep(uint32_t ms);
-	static void startTask(void task(void *), std::string taskName, void *param=nullptr, int stackSize = 2048);
+	static void startTask(void task(void *), std::string taskName, void *param=nullptr, uint32_t stackSize = 2048);
 	static void deleteTask(TaskHandle_t pTask = nullptr);
 
 	static uint32_t getTimeSinceStart();


### PR DESCRIPTION
Stack size is defined as `int`, whereas underlying function asks for `const uint32_t`. Passing in `uint32_t` satisfies the criteria and excludes ambiguity.