### PR TITLE
Release memory from CLASSIC_BT when not enabled

### DIFF
--- a/cpp_utils/BLEDevice.cpp
+++ b/cpp_utils/BLEDevice.cpp
@@ -354,13 +354,7 @@ BLEAdvertising* BLEDevice::m_bleAdvertising = nullptr;
 		}
 
 #ifndef CLASSIC_BT_ENABLED
-	//	esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);  //FIXME waiting for response from esp-idf issue
-		errRc = esp_bt_controller_enable(ESP_BT_MODE_BLE);
-		//errRc = esp_bt_controller_enable(ESP_BT_MODE_BTDM);
-		if (errRc != ESP_OK) {
-			ESP_LOGE(LOG_TAG, "esp_bt_controller_enable: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
-			return;
-		}
+		esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
 #else
 		errRc = esp_bt_controller_enable(ESP_BT_MODE_BTDM);
 		if (errRc != ESP_OK) {


### PR DESCRIPTION
There was a FIXME marker, stating that reply is pending from esp-idf team. Seems like issue has been resolved and we can use `esp_bt_controller_mem_release` safely now. (https://github.com/espressif/esp-idf/issues/1162)

I have removed the `esp_bt_controller_enable(ESP_BT_MODE_BLE)` as it causes BT controller failing to start when config has `CLASSIC_BT_ENABLED=y`. There's no more `ESP_BT_MODE_BLE`, only `ESP_BT_MODE_BTDM`, therefore I've cut out most of `#ifndef` block. (https://github.com/espressif/esp-idf/issues/405)