### PR TITLE
PWM: idle level is bool

### DIFF
--- a/cpp_utils/PWM.cpp
+++ b/cpp_utils/PWM.cpp
@@ -150,5 +150,5 @@ void PWM::setFrequency(uint32_t freq) {
  * @return N/A.
  */
 void PWM::stop(bool idleLevel) {
-	ESP_ERROR_CHECK(::ledc_stop(LEDC_HIGH_SPEED_MODE, m_channel, idleLevel));
+	ESP_ERROR_CHECK(::ledc_stop(LEDC_HIGH_SPEED_MODE, m_channel, idleLevel ? 1 : 0));
 } // stop


### PR DESCRIPTION
Passing a `bool` to function that expects an `int`. This fixes that.