### PR TITLE
WebSocket: Opcodes are uint8_t

### DIFF
--- a/cpp_utils/WebSocket.cpp
+++ b/cpp_utils/WebSocket.cpp
@@ -21,12 +21,12 @@ extern "C" {
 static const char* LOG_TAG = "WebSocket";
 
 // WebSocket op codes as found in a WebSocket frame.
-static const int OPCODE_CONTINUE = 0x00;
-static const int OPCODE_TEXT     = 0x01;
-static const int OPCODE_BINARY   = 0x02;
-static const int OPCODE_CLOSE    = 0x08;
-static const int OPCODE_PING     = 0x09;
-static const int OPCODE_PONG     = 0x0a;
+static const uint8_t OPCODE_CONTINUE = 0x00;
+static const uint8_t OPCODE_TEXT     = 0x01;
+static const uint8_t OPCODE_BINARY   = 0x02;
+static const uint8_t OPCODE_CLOSE    = 0x08;
+static const uint8_t OPCODE_PING     = 0x09;
+static const uint8_t OPCODE_PONG     = 0x0a;
 
 
 // Structure definition for the WebSocket frame.
@@ -119,7 +119,7 @@ private:
 				break;
 			}
 			ESP_LOGD("WebSocketReader", "Waiting on socket data for socket %s", peerSocket.toString().c_str());
-			int length = peerSocket.receive((uint8_t*)&frame, sizeof(frame), true); // Read exact
+			size_t length = peerSocket.receive((uint8_t*)&frame, sizeof(frame), true); // Read exact
 			if (length != sizeof(frame)) {
 				ESP_LOGD(LOG_TAG, "Socket read error");
 				pWebSocket->close();
@@ -476,7 +476,7 @@ WebSocketInputStreambuf::int_type WebSocketInputStreambuf::underflow() {
 	// We wish to refill the buffer.  We want to read data from the socket.  We want to read either
 	// the size of the buffer to fill it or the maximum number of bytes remaining to be read.
 	// We will choose which ever is smaller as the number of bytes to read into the buffer.
-	int remainingBytes = getRecordSize()-m_sizeRead;
+	size_t remainingBytes = getRecordSize()-m_sizeRead;
 	size_t sizeToRead;
 	if (remainingBytes < m_bufferSize) {
 		sizeToRead = remainingBytes;
@@ -485,7 +485,7 @@ WebSocketInputStreambuf::int_type WebSocketInputStreambuf::underflow() {
 	}
 
 	ESP_LOGD("WebSocketInputRecordStreambuf", "- getting next buffer of data; size request: %d", sizeToRead);
-	int bytesRead = m_socket.receive((uint8_t*)m_buffer, sizeToRead, true);
+	size_t bytesRead = m_socket.receive((uint8_t*)m_buffer, sizeToRead, true);
 	if (bytesRead == 0) {
 		ESP_LOGD("WebSocketInputRecordStreambuf", "<< underflow: Read 0 bytes");
 		return EOF;


### PR DESCRIPTION
There's no need for opcodes to be `int`s, uint8_t is quite enough. In fact, that eliminates some implicit type conversion\casting.

I've changed `int`s to be `size_t`s where they represent the number of bytes, too.