### PR TITLE
PCF8574 & PCF8575: i2c on heap

### DIFF
--- a/cpp_utils/PCF8574.cpp
+++ b/cpp_utils/PCF8574.cpp
@@ -18,7 +18,8 @@
  * @param [in] address The %I2C address of the device on the %I2C bus.
  */
 PCF8574::PCF8574(uint8_t address) {
-	i2c.setAddress(address);
+	i2c = new I2C();
+	i2c->setAddress(address);
 	lastWrite = 0;
 }
 
@@ -26,6 +27,7 @@ PCF8574::PCF8574(uint8_t address) {
  * @brief Class instance destructor.
  */
 PCF8574::~PCF8574() {
+	delete i2c;
 }
 
 
@@ -35,9 +37,9 @@ PCF8574::~PCF8574() {
  */
 uint8_t PCF8574::read() {
 	uint8_t value;
-	i2c.beginTransaction();
-	i2c.read(&value,true);
-	i2c.endTransaction();
+	i2c->beginTransaction();
+	i2c->read(&value,true);
+	i2c->endTransaction();
 	return value;
 } // read
 
@@ -66,9 +68,9 @@ void PCF8574::write(uint8_t value) {
 	if (invert) {
 		value = ~value;
 	}
-	i2c.beginTransaction();
-	i2c.write(value, true);
-	i2c.endTransaction();
+	i2c->beginTransaction();
+	i2c->write(value, true);
+	i2c->endTransaction();
 	lastWrite = value;
 } // write
 
@@ -117,5 +119,5 @@ void PCF8574::setInvert(bool value) {
  * @param [in] clkPin The pin to use for the %I2C CLK functions.
  */
 void PCF8574::init(gpio_num_t sdaPin, gpio_num_t clkPin) {
-	i2c.init(0, sdaPin, clkPin);
+	i2c->init(0, sdaPin, clkPin);
 } // init

--- a/cpp_utils/PCF8574.h
+++ b/cpp_utils/PCF8574.h
@@ -29,7 +29,7 @@ public:
 	void writeBit(uint8_t bit, bool value);
 
 private:
-	I2C i2c = I2C();
+	I2C* i2c;
 	uint8_t lastWrite;
 	bool invert = false;
 };

--- a/cpp_utils/PCF8575.cpp
+++ b/cpp_utils/PCF8575.cpp
@@ -18,7 +18,8 @@
  * @param [in] address The %I2C address of the device on the %I2C bus.
  */
 PCF8575::PCF8575(uint8_t address) {
-	i2c.setAddress(address);
+	i2c = new I2C();
+	i2c->setAddress(address);
 	m_lastWrite = 0;
 }
 
@@ -26,6 +27,7 @@ PCF8575::PCF8575(uint8_t address) {
  * @brief Class instance destructor.
  */
 PCF8575::~PCF8575() {
+	delete i2c;
 }
 
 
@@ -35,10 +37,10 @@ PCF8575::~PCF8575() {
  */
 uint16_t PCF8575::read() {
 	uint16_t value;
-	i2c.beginTransaction();
-	i2c.read((uint8_t*)&value,true);
-	i2c.read(((uint8_t*)&value) + 1,true);
-	i2c.endTransaction();
+	i2c->beginTransaction();
+	i2c->read((uint8_t*)&value,true);
+	i2c->read(((uint8_t*)&value) + 1,true);
+	i2c->endTransaction();
 	return value;
 } // read
 
@@ -67,10 +69,10 @@ void PCF8575::write(uint16_t value) {
 	if (invert) {
 		value = ~value;
 	}
-	i2c.beginTransaction();
-	i2c.write(value & 0xff, true);
-	i2c.write((value >> 8) & 0xff, true);
-	i2c.endTransaction();
+	i2c->beginTransaction();
+	i2c->write(value & 0xff, true);
+	i2c->write((value >> 8) & 0xff, true);
+	i2c->endTransaction();
 	m_lastWrite = value;
 } // write
 
@@ -119,5 +121,5 @@ void PCF8575::setInvert(bool value) {
  * @param [in] clkPin The pin to use for the %I2C CLK functions.
  */
 void PCF8575::init(gpio_num_t sdaPin, gpio_num_t clkPin) {
-	i2c.init(0, sdaPin, clkPin);
+	i2c->init(0, sdaPin, clkPin);
 } // init

--- a/cpp_utils/PCF8575.h
+++ b/cpp_utils/PCF8575.h
@@ -29,8 +29,8 @@ public:
 	void     writeBit(uint16_t bit, bool value);
 
 private:
-	I2C     i2c = I2C();
-	uint8_t m_lastWrite;
+	I2C* i2c;
+	uint16_t m_lastWrite;
 	bool    invert = false;
 };
 


### PR DESCRIPTION
Changed I2C instance to be hosted on the heap for these two drivers.

Seems like PCF8575 is writing `uint16_t` whereas PCF8574 is operating on `uint8_t`s. I've changed the type to represent the structure better.