### PR TITLE
Add access to remote address in BLERemoteCharacteristic

### DIFF
--- a/cpp_utils/BLERemoteCharacteristic.cpp
+++ b/cpp_utils/BLERemoteCharacteristic.cpp
@@ -582,5 +582,13 @@ void BLERemoteCharacteristic::writeValue(uint8_t* data, size_t length, bool resp
 uint8_t* BLERemoteCharacteristic::readRawData() {
 	return m_rawData;
 }
+/**
+ * @brief Get the address of the remote server
+ * @return RemoteAddress
+ */
+BLEAddress  BLERemoteCharacteristic::getRemoteAddress(){
+	return m_pRemoteService->getClient()->getPeerAddress();
+}
+
 
 #endif /* CONFIG_BT_ENABLED */

--- a/cpp_utils/BLERemoteCharacteristic.h
+++ b/cpp_utils/BLERemoteCharacteristic.h
@@ -51,6 +51,7 @@ public:
 	void        writeValue(uint8_t newValue, bool response = false);
 	std::string toString();
 	uint8_t*	readRawData();
+	BLEAddress  getRemoteAddress();
 
 private:
 	BLERemoteCharacteristic(uint16_t handle, BLEUUID uuid, esp_gatt_char_prop_t charProp, BLERemoteService* pRemoteService);


### PR DESCRIPTION
Add access to remote address in BLERemoteCharacteristic to distinguish different servers with same characteristic uuid within notifyhandler