### PR TITLE
Fix error:  'BLEAddress' does not name a type

### DIFF
--- a/cpp_utils/BLERemoteCharacteristic.h
+++ b/cpp_utils/BLERemoteCharacteristic.h
@@ -17,6 +17,7 @@
 #include "BLERemoteService.h"
 #include "BLERemoteDescriptor.h"
 #include "BLEUUID.h"
+#include "BLEAddress.h"
 #include "FreeRTOS.h"
 
 class BLERemoteService;


### PR DESCRIPTION
**When:**
Compiling a project.
**Where:**
Line 54 in: BLEAddress  getRemoteAddress();
**Drops error:**
'BLEAddress' does not name a type
**My Solution:**
Add the include: #include "BLEAddress.h"