### PR TITLE
init should not set I2C addr to 0

### DIFF
--- a/cpp_utils/PCF8574.cpp
+++ b/cpp_utils/PCF8574.cpp
@@ -116,5 +116,6 @@ void PCF8574::setInvert(bool value) {
  * @param [in] clkPin The pin to use for the %I2C CLK functions.
  */
 void PCF8574::init(gpio_num_t sdaPin, gpio_num_t clkPin) {
-	i2c->init(0, sdaPin, clkPin);
+    uint8_t addr = i2c->getAddress();
+    i2c->init(addr, sdaPin, clkPin);
 } // init


### PR DESCRIPTION
init takes sdaPin and clkPin but does not take an I2C address.  Therefore the call to init should not set the I2C address to 0.  It should leave it alone.