### PR TITLE
Add CMake support

### DIFF
--- a/cpp_utils/CMakeLists.txt
+++ b/cpp_utils/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Edit following two lines to set component requirements (see docs)
+set(COMPONENT_REQUIRES )
+set(COMPONENT_PRIV_REQUIRES )
+
+set(COMPONENT_ADD_INCLUDEDIRS ".")
+
+register_component()

--- a/cpp_utils/CMakeLists.txt
+++ b/cpp_utils/CMakeLists.txt
@@ -1,7 +1,20 @@
 # Edit following two lines to set component requirements (see docs)
-set(COMPONENT_REQUIRES )
+set(COMPONENT_REQUIRES
+  "console"
+  "fatfs"
+  "json"
+  "mdns"
+  "nvs_flash"
+)
 set(COMPONENT_PRIV_REQUIRES )
 
+file(GLOB COMPONENT_SRCS
+  LIST_DIRECTORIES false
+  "*.h"
+  "*.cpp"
+  "*.c"
+  "*.S"
+)
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
 register_component()


### PR DESCRIPTION
ESP-IDF supports (in preview) CMake for generating projects. 
This PR adds CMake support for the `cpp_utils` component