### PR TITLE
Add automatic documentation via GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,12 @@
 .vs/
 .idea/
 
+# OS Meta
+.DS_Store
+
 # CMake
 cmake-build-debug/
+
+# Generated docs
+html/
+latex/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ jobs:
         - cd cpp_utils
         - doxygen .
 
+branches:
+  only:
+    - srounce-add-gh-pages
+
 stages:
   - build-docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+
+addons:
+  apt:
+    packages:
+    - doxygen
+
+jobs:
+  include:
+    - stage: build-docs
+      script:
+        - cd cpp_utils
+        - doxygen .
+
+stages:
+  - build-docs
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep-history: true
+  local-dir: cpp_utils/html
+  on:
+    branch: srounce-add-gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
 
 branches:
   only:
-    - srounce-add-gh-pages
+    - master
 
 stages:
   - build-docs
@@ -26,4 +26,4 @@ deploy:
   keep-history: true
   local-dir: cpp_utils/html
   on:
-    branch: srounce-add-gh-pages
+    branch: master


### PR DESCRIPTION
# 🎅🎄🎁☃️👼❄️🌟

### Pretty self-explanatory really. 
1) Commits go into master
2) Doxygen gets run in Travis CI environment and generates `cpp_utils` documentation 
3) HTML gets published to https://nkolban.github.io/esp32-snippets.

### Todo:
Before merging the following will have to be done by someone with the required access level to this repository:
- [ ] Setup Travis CI account (free for OSS)
- [ ] [Generate token and add to CI variables as per instructions](https://docs.travis-ci.com/user/deployment/pages/#setting-the-github-token)
- [ ] Have a very Merry Christmas 🥂