### PR TITLE
Notify after setBatteryLevel

### DIFF
--- a/cpp_utils/BLEHIDDevice.cpp
+++ b/cpp_utils/BLEHIDDevice.cpp
@@ -194,6 +194,7 @@ BLECharacteristic* BLEHIDDevice::protocolMode() {
 
 void BLEHIDDevice::setBatteryLevel(uint8_t level) {
 	m_batteryLevelCharacteristic->setValue(&level, 1);
+	m_batteryLevelCharacteristic->notify();
 }
 /*
  * @brief Returns battery level characteristic


### PR DESCRIPTION
I'm building a BLE HID keyboard and can confirm that the notify is necessary for the BT client (in this case a PC) to update its battery indicator. Tested under Linux with Gnome and Windows 10.