### PR TITLE
FreeRTOS giveFromISR() when releasing within a handler

### DIFF
--- a/cpp_utils/BLEAdvertising.cpp
+++ b/cpp_utils/BLEAdvertising.cpp
@@ -480,15 +480,15 @@ void BLEAdvertising::handleGAPEvent(
 
 	switch(event) {
 		case ESP_GAP_BLE_ADV_DATA_SET_COMPLETE_EVT: {
-			// m_semaphoreSetAdv.give();
+			// m_semaphoreSetAdv.giveFromISR();
 			break;
 		}
 		case ESP_GAP_BLE_SCAN_RSP_DATA_SET_COMPLETE_EVT: {
-			// m_semaphoreSetAdv.give();
+			// m_semaphoreSetAdv.giveFromISR();
 			break;
 		}
 		case ESP_GAP_BLE_ADV_START_COMPLETE_EVT: {
-			// m_semaphoreSetAdv.give();
+			// m_semaphoreSetAdv.giveFromISR();
 			break;
 		}
 		case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT: {

--- a/cpp_utils/BLECharacteristic.cpp
+++ b/cpp_utils/BLECharacteristic.cpp
@@ -261,7 +261,7 @@ void BLECharacteristic::handleGATTServerEvent(
 				// 	pDescriptor->executeCreate(this);
 				// 	pDescriptor = m_descriptorMap.getNext();
 				// } // End while
-				m_semaphoreCreateEvt.give();
+				m_semaphoreCreateEvt.giveFromISR();
 			}
 			break;
 		} // ESP_GATTS_ADD_CHAR_EVT
@@ -440,7 +440,7 @@ void BLECharacteristic::handleGATTServerEvent(
 		case ESP_GATTS_CONF_EVT: {
 			// ESP_LOGD(LOG_TAG, "m_handle = %d, conf->handle = %d", m_handle, param->conf.handle);
 			if(param->conf.conn_id == getService()->getServer()->getConnId()) // && param->conf.handle == m_handle) // bug in esp-idf and not implemented in arduino yet
-				m_semaphoreConfEvt.give(param->conf.status);
+				m_semaphoreConfEvt.giveFromISR(param->conf.status);
 			break;
 		}
 
@@ -449,7 +449,7 @@ void BLECharacteristic::handleGATTServerEvent(
 		}
 
 		case ESP_GATTS_DISCONNECT_EVT: {
-			m_semaphoreConfEvt.give();
+			m_semaphoreConfEvt.giveFromISR();
 			break;
 		}
 

--- a/cpp_utils/BLEClient.cpp
+++ b/cpp_utils/BLEClient.cpp
@@ -193,7 +193,7 @@ void BLEClient::gattClientEventHandler(
 			ESP_LOGE(__func__, "disconnect event, reason: %d, connId: %d, my connId: %d, my IF: %d, gattc_if: %d", (int)evtParam->disconnect.reason, evtParam->disconnect.conn_id, getConnId(), getGattcIf(), gattc_if);
 			if(m_gattc_if != gattc_if)
 				break;
-			m_semaphoreOpenEvt.give(evtParam->disconnect.reason);
+			m_semaphoreOpenEvt.giveFromISR(evtParam->disconnect.reason);
 			if(!m_isConnected)
 				break;
 			// If we receive a disconnect event, set the class flag that indicates that we are

--- a/cpp_utils/BLERemoteCharacteristic.cpp
+++ b/cpp_utils/BLERemoteCharacteristic.cpp
@@ -197,7 +197,7 @@ void BLERemoteCharacteristic::gattClientEventHandler(esp_gattc_cb_event_t event,
 				m_value = "";
 			}
 
-			m_semaphoreReadCharEvt.give();
+			m_semaphoreReadCharEvt.giveFromISR();
 			break;
 		} // ESP_GATTC_READ_CHAR_EVT
 
@@ -211,7 +211,7 @@ void BLERemoteCharacteristic::gattClientEventHandler(esp_gattc_cb_event_t event,
 			if (evtParam->reg_for_notify.handle != getHandle()) break;
 
 			// We have processed the notify registration and can unlock the semaphore.
-			m_semaphoreRegForNotifyEvt.give();
+			m_semaphoreRegForNotifyEvt.giveFromISR();
 			break;
 		} // ESP_GATTC_REG_FOR_NOTIFY_EVT
 
@@ -223,7 +223,7 @@ void BLERemoteCharacteristic::gattClientEventHandler(esp_gattc_cb_event_t event,
 		case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
 			if (evtParam->unreg_for_notify.handle != getHandle()) break;
 			// We have processed the notify un-registration and can unlock the semaphore.
-			m_semaphoreRegForNotifyEvt.give();
+			m_semaphoreRegForNotifyEvt.giveFromISR();
 			break;
 		} // ESP_GATTC_UNREG_FOR_NOTIFY_EVT:
 
@@ -239,7 +239,7 @@ void BLERemoteCharacteristic::gattClientEventHandler(esp_gattc_cb_event_t event,
 
 			// There is nothing further we need to do here.  This is merely an indication
 			// that the write has completed and we can unlock the caller.
-			m_semaphoreWriteCharEvt.give();
+			m_semaphoreWriteCharEvt.giveFromISR();
 			break;
 		} // ESP_GATTC_WRITE_CHAR_EVT
 

--- a/cpp_utils/BLEScan.cpp
+++ b/cpp_utils/BLEScan.cpp
@@ -77,7 +77,7 @@ void BLEScan::handleGAPEvent(
 				case ESP_GAP_SEARCH_INQ_CMPL_EVT: {
 					ESP_LOGW(LOG_TAG, "ESP_GAP_SEARCH_INQ_CMPL_EVT");
 					m_stopped = true;
-					m_semaphoreScanEnd.give();
+					m_semaphoreScanEnd.giveFromISR();
 					if (m_scanCompleteCB != nullptr) {
 						m_scanCompleteCB(m_scanResults);
 					}

--- a/cpp_utils/BLEService.cpp
+++ b/cpp_utils/BLEService.cpp
@@ -307,7 +307,7 @@ void BLEService::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t
 		// uint16_t service_handle
 		case ESP_GATTS_START_EVT: {
 			if (param->start.service_handle == getHandle()) {
-				m_semaphoreStartEvt.give();
+				m_semaphoreStartEvt.giveFromISR();
 			}
 			break;
 		} // ESP_GATTS_START_EVT
@@ -320,7 +320,7 @@ void BLEService::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t
 		//
 		case ESP_GATTS_STOP_EVT: {
 			if (param->stop.service_handle == getHandle()) {
-				m_semaphoreStopEvt.give();
+				m_semaphoreStopEvt.giveFromISR();
 			}
 			break;
 		} // ESP_GATTS_STOP_EVT
@@ -341,7 +341,7 @@ void BLEService::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t
 		case ESP_GATTS_CREATE_EVT: {
 			if (getUUID().equals(BLEUUID(param->create.service_id.id.uuid)) && m_instId == param->create.service_id.id.inst_id) {
 				setHandle(param->create.service_handle);
-				m_semaphoreCreateEvt.give();
+				m_semaphoreCreateEvt.giveFromISR();
 			}
 			break;
 		} // ESP_GATTS_CREATE_EVT
@@ -356,7 +356,7 @@ void BLEService::handleGATTServerEvent(esp_gatts_cb_event_t event, esp_gatt_if_t
 		//
 		case ESP_GATTS_DELETE_EVT: {
 			if (param->del.service_handle == getHandle()) {
-				m_semaphoreDeleteEvt.give();
+				m_semaphoreDeleteEvt.giveFromISR();
 			}
 			break;
 		} // ESP_GATTS_DELETE_EVT


### PR DESCRIPTION
Due to a recent [commit](https://github.com/espressif/esp-idf/commit/13523c95b42c77b4263ef98ce054962bcb338636#diff-c5ba8f58d17f548eadd9bda941fe71d4)  (#13523c95b42c77b4263ef98ce054962bcb338636) to esp-idf, when releasing a semaphore from within a handler, it is required to use giveFromISR() instead of give(), or an assert (freertos/queue.c:729) that verifies the release request is from the current owner will fail. I have made this change to all locations within cpp_utils where semaphore.give() was invoked from within a callback or handler, since freertos semaphore handling is generic.

I have not verified this works on pre-commit versions of esp-idf.