### PR TITLE
Fix ring buffer compilation error

### DIFF
--- a/cpp_utils/BLEAddress.cpp
+++ b/cpp_utils/BLEAddress.cpp
@@ -22,7 +22,8 @@
  * @brief Create an address from the native ESP32 representation.
  * @param [in] address The native representation.
  */
-BLEAddress::BLEAddress(esp_bd_addr_t address) {
+BLEAddress::BLEAddress(esp_bd_addr_t address, esp_ble_wl_addr_type_t type) {
+    m_type = type;
 	memcpy(m_address, address, ESP_BD_ADDR_LEN);
 } // BLEAddress
 
@@ -38,7 +39,8 @@ BLEAddress::BLEAddress(esp_bd_addr_t address) {
  *
  * @param [in] stringAddress The hex representation of the address.
  */
-BLEAddress::BLEAddress(std::string stringAddress) {
+BLEAddress::BLEAddress(std::string stringAddress, esp_ble_wl_addr_type_t type) {
+    m_type = type;
 	if (stringAddress.length() != 17) return;
 
 	int data[6];
@@ -58,7 +60,7 @@ BLEAddress::BLEAddress(std::string stringAddress) {
  * @return True if the addresses are equal.
  */
 bool BLEAddress::equals(BLEAddress otherAddress) {
-	return memcmp(otherAddress.getNative(), m_address, 6) == 0;
+	return memcmp(otherAddress.getNative(), m_address, 6) == 0 && m_type == otherAddress.m_type;
 } // equals
 
 
@@ -92,4 +94,9 @@ std::string BLEAddress::toString() {
 	stream << std::setfill('0') << std::setw(2) << std::hex << (int) ((uint8_t*) (m_address))[5];
 	return stream.str();
 } // toString
+
+esp_ble_wl_addr_type_t BLEAddress::getType() const {
+    return m_type;
+}
+
 #endif

--- a/cpp_utils/BLEAddress.h
+++ b/cpp_utils/BLEAddress.h
@@ -20,14 +20,16 @@
  */
 class BLEAddress {
 public:
-	BLEAddress(esp_bd_addr_t address);
-	BLEAddress(std::string stringAddress);
+	BLEAddress(esp_bd_addr_t address, esp_ble_wl_addr_type_t type = BLE_WL_ADDR_TYPE_RANDOM);
+	BLEAddress(std::string stringAddress, esp_ble_wl_addr_type_t type = BLE_WL_ADDR_TYPE_RANDOM);
 	bool           equals(BLEAddress otherAddress);
 	esp_bd_addr_t* getNative();
 	std::string    toString();
+    esp_ble_wl_addr_type_t getType() const;
 
 private:
 	esp_bd_addr_t m_address;
+    esp_ble_wl_addr_type_t m_type;
 };
 
 #endif /* CONFIG_BT_ENABLED */

--- a/cpp_utils/BLEDevice.cpp
+++ b/cpp_utils/BLEDevice.cpp
@@ -485,7 +485,7 @@ gatts_event_handler BLEDevice::m_customGattsHandler = nullptr;
  */
 void BLEDevice::whiteListAdd(BLEAddress address) {
 	ESP_LOGD(LOG_TAG, ">> whiteListAdd: %s", address.toString().c_str());
-	esp_err_t errRc = esp_ble_gap_update_whitelist(true, *address.getNative());  // True to add an entry.
+	esp_err_t errRc = esp_ble_gap_update_whitelist(true, *address.getNative(), address.getType());  // True to add an entry.
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "esp_ble_gap_update_whitelist: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 	}
@@ -499,7 +499,7 @@ void BLEDevice::whiteListAdd(BLEAddress address) {
  */
 void BLEDevice::whiteListRemove(BLEAddress address) {
 	ESP_LOGD(LOG_TAG, ">> whiteListRemove: %s", address.toString().c_str());
-	esp_err_t errRc = esp_ble_gap_update_whitelist(false, *address.getNative());  // False to remove an entry.
+	esp_err_t errRc = esp_ble_gap_update_whitelist(false, *address.getNative(), address.getType());  // False to remove an entry.
 	if (errRc != ESP_OK) {
 		ESP_LOGE(LOG_TAG, "esp_ble_gap_update_whitelist: rc=%d %s", errRc, GeneralUtils::errorToString(errRc));
 	}

--- a/cpp_utils/FreeRTOS.cpp
+++ b/cpp_utils/FreeRTOS.cpp
@@ -229,7 +229,7 @@ void FreeRTOS::Semaphore::setName(std::string name) {
  * @param [in] length The amount of storage to allocate for the ring buffer.
  * @param [in] type The type of buffer.  One of RINGBUF_TYPE_NOSPLIT, RINGBUF_TYPE_ALLOWSPLIT, RINGBUF_TYPE_BYTEBUF.
  */
-Ringbuffer::Ringbuffer(size_t length, ringbuf_type_t type) {
+Ringbuffer::Ringbuffer(size_t length, RingbufferType_t type) {
 	m_handle = ::xRingbufferCreate(length, type);
 } // Ringbuffer
 

--- a/cpp_utils/FreeRTOS.h
+++ b/cpp_utils/FreeRTOS.h
@@ -58,7 +58,7 @@ public:
  */
 class Ringbuffer {
 public:
-	Ringbuffer(size_t length, ringbuf_type_t type = RINGBUF_TYPE_NOSPLIT);
+	Ringbuffer(size_t length, RingbufferType_t type = RINGBUF_TYPE_NOSPLIT);
 	~Ringbuffer();
 
 	void*    receive(size_t* size, TickType_t wait = portMAX_DELAY);

--- a/cpp_utils/HttpRequest.cpp
+++ b/cpp_utils/HttpRequest.cpp
@@ -39,7 +39,7 @@
 #include "GeneralUtils.h"
 
 #include <esp_log.h>
-#include <hwcrypto/sha.h>
+#include <esp32/sha.h>
 
 #define STATE_NAME  0
 #define STATE_VALUE 1

--- a/cpp_utils/PWM.cpp
+++ b/cpp_utils/PWM.cpp
@@ -37,6 +37,7 @@ PWM::PWM(int gpioNum, uint32_t frequency, ledc_timer_bit_t dutyResolution, ledc_
 	timer_conf.freq_hz    = frequency;
 	timer_conf.speed_mode = LEDC_HIGH_SPEED_MODE;
 	timer_conf.timer_num  = timer;
+	timer_conf.clk_cfg    = LEDC_AUTO_CLK;
 	ESP_ERROR_CHECK(::ledc_timer_config(&timer_conf));
 
 	ledc_channel_config_t ledc_conf;
@@ -46,6 +47,7 @@ PWM::PWM(int gpioNum, uint32_t frequency, ledc_timer_bit_t dutyResolution, ledc_
 	ledc_conf.intr_type  = LEDC_INTR_DISABLE;
 	ledc_conf.speed_mode = LEDC_HIGH_SPEED_MODE;
 	ledc_conf.timer_sel  = timer;
+	ledc_conf.hpoint     = 0;
 	ESP_ERROR_CHECK(::ledc_channel_config(&ledc_conf));
 
 	this->m_channel        = channel;

--- a/cpp_utils/Provisioning.cpp
+++ b/cpp_utils/Provisioning.cpp
@@ -1,0 +1,38 @@
+/*
+ * Provisioning.cpp
+ *
+ *  Created on: Jan 05, 2021
+ *      Author: kchugalinskiy
+ */
+
+
+#include "Provisioning.h"
+
+namespace Provisioning {
+
+WiFi::WiFi(wifi_prov_scheme_t scheme, wifi_prov_event_handler_t scheme_event_handler, wifi_prov_event_handler_t app_event_handler) {
+	wifi_prov_mgr_config_t config {
+		.scheme = scheme,
+		.scheme_event_handler = scheme_event_handler,
+		.app_event_handler = app_event_handler
+	};
+	ESP_ERROR_CHECK(wifi_prov_mgr_init(config));
+}
+
+WiFi::~WiFi() {
+	wifi_prov_mgr_deinit();
+}
+
+void WiFi::Start(const char *pop, const char *service_name, const char *service_key, wifi_prov_security_t security) {
+	ESP_ERROR_CHECK(wifi_prov_mgr_start_provisioning(security, pop, service_name, service_key));
+}
+
+void WiFi::Stop() {
+	wifi_prov_mgr_stop_provisioning();
+}
+
+void WiFi::Wait() {
+	wifi_prov_mgr_wait();
+}
+
+} // namespace Provisioning

--- a/cpp_utils/Provisioning.h
+++ b/cpp_utils/Provisioning.h
@@ -1,0 +1,33 @@
+/*
+ * Provisioning.h
+ *
+ *  Created on: Jan 05, 2021
+ *      Author: kchugalinskiy
+ */
+#ifndef CPP_UTILS_PROVISIONING_H_
+#define CPP_UTILS_PROVISIONING_H_
+
+#include "wifi_provisioning/manager.h"
+
+namespace Provisioning {
+
+class WiFi {
+public:
+	WiFi(wifi_prov_scheme_t scheme, wifi_prov_event_handler_t scheme_event_handler = WIFI_PROV_EVENT_HANDLER_NONE,
+				wifi_prov_event_handler_t app_event_handler = WIFI_PROV_EVENT_HANDLER_NONE);
+	~WiFi();
+
+	void Start(const char *pop, const char *service_name, const char *service_key = nullptr, wifi_prov_security_t security = WIFI_PROV_SECURITY_1);
+	void Stop();
+	void Wait();
+
+private:
+	// copy and assignment are discouraged.
+	WiFi(const WiFi &) = delete;
+
+	void operator=(const WiFi &) = delete;
+};
+
+} // namespace Provisioning
+
+#endif //CPP_UTILS_PROVISIONING_H_

--- a/cpp_utils/SockServ.cpp
+++ b/cpp_utils/SockServ.cpp
@@ -70,7 +70,7 @@ SockServ::~SockServ() {
 			pSockServ->m_clientSet.insert(tempSock);
 			xQueueSendToBack(pSockServ->m_acceptQueue, &tempSock, portMAX_DELAY);
 			pSockServ->m_clientSemaphore.give();
-		} catch (std::exception e) {
+		} catch (std::exception &e) {
 			ESP_LOGD(LOG_TAG, "acceptTask ending");
 			pSockServ->m_clientSemaphore.give();   // Wake up any waiting clients.
 			FreeRTOS::deleteTask();

--- a/cpp_utils/Socket.cpp
+++ b/cpp_utils/Socket.cpp
@@ -60,7 +60,7 @@ Socket Socket::accept() {
 	ESP_LOGD(LOG_TAG, ">> accept: Accepting on %s; sockFd: %d, using SSL: %d", addressToString(&addr).c_str(), m_sock, getSSL());
 	struct sockaddr_in client_addr;
 	socklen_t sin_size;
-	int clientSockFD = ::lwip_accept_r(m_sock,  (struct sockaddr*) &client_addr, &sin_size);
+	int clientSockFD = ::lwip_accept(m_sock,  (struct sockaddr*) &client_addr, &sin_size);
 	//printf("------> new connection client %s:%d\n", inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
 	if (clientSockFD == -1) {
 		SocketException se(errno);
@@ -117,7 +117,7 @@ int Socket::bind(uint16_t port, uint32_t address) {
 	serverAddress.sin_family      = AF_INET;
 	serverAddress.sin_addr.s_addr = htonl(address);
 	serverAddress.sin_port        = htons(port);
-	int rc = ::lwip_bind_r(m_sock, (struct sockaddr*) &serverAddress, sizeof(serverAddress));
+	int rc = ::lwip_bind(m_sock, (struct sockaddr*) &serverAddress, sizeof(serverAddress));
 	if (rc != 0) {
 		ESP_LOGE(LOG_TAG, "<< bind: bind[socket=%d]: %d: %s", m_sock, errno, strerror(errno));
 		return rc;
@@ -144,7 +144,7 @@ int Socket::close() {
 	rc = 0;
 	if (m_sock != -1) {
 		ESP_LOGD(LOG_TAG, "Calling lwip_close on %d", m_sock);
-		rc = ::lwip_close_r(m_sock);
+		rc = ::lwip_close(m_sock);
 		if (rc != 0) {
 			ESP_LOGE(LOG_TAG, "Error with lwip_close: %d", rc);
 		}
@@ -170,7 +170,7 @@ int Socket::connect(struct in_addr address, uint16_t port) {
 	inet_ntop(AF_INET, &address, msg, sizeof(msg));
 	ESP_LOGD(LOG_TAG, "Connecting to %s:[%d]", msg, port);
 	createSocket();
-	int rc = ::lwip_connect_r(m_sock, (struct sockaddr*) &serverAddress, sizeof(struct sockaddr_in));
+	int rc = ::lwip_connect(m_sock, (struct sockaddr*) &serverAddress, sizeof(struct sockaddr_in));
 	if (rc == -1) {
 		ESP_LOGE(LOG_TAG, "connect_cpp: Error: %s", strerror(errno));
 		close();
@@ -268,7 +268,7 @@ int Socket::listen(uint16_t port, bool isDatagram, bool reuseAddress) {
 	// For a datagram socket, we don't execute a listen call.  That is is only for connection oriented
 	// sockets.
 	if (!isDatagram) {
-		rc = ::lwip_listen_r(m_sock, 5);
+		rc = ::lwip_listen(m_sock, 5);
 		if (rc == -1) {
 			ESP_LOGE(LOG_TAG, "<< listen: %s", strerror(errno));
 			return rc;
@@ -356,7 +356,7 @@ size_t Socket::receive(uint8_t* data, size_t length, bool exact) {
 				ESP_LOGD(LOG_TAG, "rc=%d, MBEDTLS_ERR_SSL_WANT_READ=%d", rc, MBEDTLS_ERR_SSL_WANT_READ);
 			} while (rc == MBEDTLS_ERR_SSL_WANT_WRITE || rc == MBEDTLS_ERR_SSL_WANT_READ);
 		} else {
-			rc = ::lwip_recv_r(m_sock, data, length, 0);
+			rc = ::lwip_recv(m_sock, data, length, 0);
 			if (rc == -1) {
 				ESP_LOGE(LOG_TAG, "receive: %s", strerror(errno));
 			}
@@ -374,7 +374,7 @@ size_t Socket::receive(uint8_t* data, size_t length, bool exact) {
 				rc = mbedtls_ssl_read(&m_sslContext, data, amountToRead);
 			} while (rc == MBEDTLS_ERR_SSL_WANT_WRITE || rc == MBEDTLS_ERR_SSL_WANT_READ);
 		} else {
-			rc = ::lwip_recv_r(m_sock, data, amountToRead, 0);
+			rc = ::lwip_recv(m_sock, data, amountToRead, 0);
 		}
 		if (rc == -1) {
 			ESP_LOGE(LOG_TAG, "receive: %s", strerror(errno));
@@ -432,7 +432,7 @@ int Socket::send(const uint8_t* data, size_t length) const {
 				}
 			}
 		} else {
-			rc = ::lwip_send_r(m_sock, data, length, 0);
+			rc = ::lwip_send(m_sock, data, length, 0);
 			if ((rc < 0) && (errno != EAGAIN)) {
 				// no cure for errors other than EAGAIN - log and exit
 				ESP_LOGE(LOG_TAG, "send: socket=%d, %s", m_sock, strerror(errno));

--- a/cpp_utils/WiFi.cpp
+++ b/cpp_utils/WiFi.cpp
@@ -218,8 +218,8 @@ void WiFi::dump() {
 	ESP_LOGD(LOG_TAG, "WiFi Dump");
 	ESP_LOGD(LOG_TAG, "---------");
 	char ipAddrStr[30];
-	ip_addr_t ip = ::dns_getserver(0);
-	inet_ntop(AF_INET, &ip, ipAddrStr, sizeof(ipAddrStr));
+    const ip_addr_t* ip = ::dns_getserver(0);
+	inet_ntop(AF_INET, ip, ipAddrStr, sizeof(ipAddrStr));
 	ESP_LOGD(LOG_TAG, "DNS Server[0]: %s", ipAddrStr);
 } // dump
 


### PR DESCRIPTION
Current version of idf provides alternative naming for ring buffer type. [see this for details](https://github.com/espressif/esp-idf/blob/master/components/esp_ringbuf/include/freertos/ringbuf.h#L33)